### PR TITLE
Run Frontend CI only when changes occur in the frontend folder

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
   push:
   pull_request:
-    branches: ["test/ci-setup"]
+    branches: ["main"]
 
 jobs:
 

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -6,11 +6,14 @@ name: Frontend CI
 on:
   workflow_dispatch:
   push:
+    paths:
+      - 'frontend/**'
   pull_request:
     branches: ["main"]
+    paths:
+      - 'frontend/**'
 
 jobs:
-
   build-test:
     runs-on: ubuntu-latest
     defaults:
@@ -23,52 +26,26 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
+      - uses: actions/checkout@v4
 
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      # Checks to see if any files in the PR are located under the frontend folder.
-      # We can use this filter to decide whether or not to run a specific step.
-      # You can check if a change occured inside the frontend directory by doing:
-      # if: ${{ steps.filter.outputs.frontend == 'true' }}
-      # It is possible however to check the filter before running the steps.
-      # See https://github.com/dorny/paths-filter?tab=readme-ov-file#examples to find examples.
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          # The base branch from which the changes will be detected (can be a tag or a commit as well).
-          # ${{ github.ref }} means that the changes will be detected from the committed files.
-          # By default, the base is set to the repository's default branch, which is main.
-          # See https://github.com/dorny/paths-filter?tab=readme-ov-file#usage
-          base: ${{ github.ref }}
-          filters: |
-            frontend:
-            - 'frontend/**'
-            
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        if: ${{ steps.filter.outputs.frontend == 'true' }}
         with:
           version: 10
           run_install: false
 
       - name: Install Node.js ${{ matrix.node-version }}
-        if: ${{ steps.filter.outputs.frontend == 'true' }}
         uses: actions/setup-node@v4
-        
         with:
           node-version: ${{ matrix.node-version }}
           cache-dependency-path: frontend/pnpm-lock.yaml
           cache: "pnpm"
 
       - name: Install dependencies
-        if: ${{ steps.filter.outputs.frontend == 'true' }}
         run: pnpm install
 
       - name: Build project
-        if: ${{ steps.filter.outputs.frontend == 'true' }}
         run: pnpm run build
 
       - name: Run tests
-        if: ${{ steps.filter.outputs.frontend == 'true' }}
         run: pnpm test

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
   push:
   pull_request:
-    branches: ["main"]
+    branches: ["test/ci-setup"]
 
 jobs:
 

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -42,25 +42,28 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
+        if: ${{ steps.filter.outputs.frontend == 'true' }}
         with:
           version: 10
           run_install: false
 
       - name: Install Node.js ${{ matrix.node-version }}
+        if: ${{ steps.filter.outputs.frontend == 'true' }}
         uses: actions/setup-node@v4
+        
         with:
           node-version: ${{ matrix.node-version }}
           cache-dependency-path: frontend/pnpm-lock.yaml
           cache: "pnpm"
 
       - name: Install dependencies
-        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        if: ${{ steps.filter.outputs.frontend == 'true' }}
         run: pnpm install
 
       - name: Build project
-        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        if: ${{ steps.filter.outputs.frontend == 'true' }}
         run: pnpm run build
 
       - name: Run tests
-        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        if: ${{ steps.filter.outputs.frontend == 'true' }}
         run: pnpm test

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -36,10 +36,11 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          base: ${{ github.ref }}
           filters: |
             frontend:
             - 'frontend/**'
-
+            
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         if: ${{ steps.filter.outputs.frontend == 'true' }}

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Checks to see if any files in the PR are located under the frontend folder.
       # We can use this filter to decide whether or not to run a specific step.

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -24,7 +24,8 @@ jobs:
 
     steps:
 
-    
+      - name: Checkout
+        uses: actions/checkout@v4
 
       # Checks to see if any files in the PR are located under the frontend folder.
       # We can use this filter to decide whether or not to run a specific step.
@@ -38,9 +39,6 @@ jobs:
           filters: |
             frontend:
             - 'frontend/**'
-  
-      - name: Checkout
-        uses: actions/checkout@v4
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -10,6 +10,7 @@ on:
     branches: ["main"]
 
 jobs:
+
   build-test:
     runs-on: ubuntu-latest
     defaults:
@@ -22,7 +23,22 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - uses: actions/checkout@v4
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # Checks to see if any files in the PR are located under the frontend folder.
+      # We can use this filter to decide whether or not to run a specific step.
+      # You can check if a change occured inside the frontend directory by doing:
+      # if: ${{ steps.filter.outputs.frontend == 'true' }}
+      # It is possible however to check the filter before running the steps.
+      # See https://github.com/dorny/paths-filter?tab=readme-ov-file#examples to find examples.
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            frontend:
+            - 'frontend/**'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -38,10 +54,13 @@ jobs:
           cache: "pnpm"
 
       - name: Install dependencies
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
         run: pnpm install
 
       - name: Build project
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
         run: pnpm run build
 
       - name: Run tests
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
         run: pnpm test

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -36,6 +36,10 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          # The base branch from which the changes will be detected (can be a tag or a commit as well).
+          # ${{ github.ref }} means that the changes will be detected from the committed files.
+          # By default, the base is set to the repository's default branch, which is main.
+          # See https://github.com/dorny/paths-filter?tab=readme-ov-file#usage
           base: ${{ github.ref }}
           filters: |
             frontend:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -24,8 +24,7 @@ jobs:
 
     steps:
 
-      - name: Checkout
-        uses: actions/checkout@v4
+    
 
       # Checks to see if any files in the PR are located under the frontend folder.
       # We can use this filter to decide whether or not to run a specific step.
@@ -39,6 +38,9 @@ jobs:
           filters: |
             frontend:
             - 'frontend/**'
+  
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/README.md
+++ b/README.md
@@ -144,3 +144,4 @@ Mettre à jour les dépendances:
 ### Utiliser Tox pour tester votre code
 
     tox -v
+

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -27,4 +27,3 @@ enableMocking().then(() => {
 		</StrictMode>,
 	);
 });
-

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -27,3 +27,4 @@ enableMocking().then(() => {
 		</StrictMode>,
 	);
 });
+


### PR DESCRIPTION
### Description
Nocodb: [Configurer la CI Github](https://noco.services.dataforgood.fr/dashboard/#/nc/pklm80q75uhsz8n/mmjq6rg3wtdmv4d/vww0imokupold6eo?rowId=74)

Ne déclencher la chaîne de build Frontend CI que si un fichier du dossier frontend est modifié.

Note : Le workflow Frontend CI étant déclenché à chaque push, le filtre est configuré pour ne s'appliquer qu'aux changements apportés par le dernier push.
De plus, le filtre est configuré pour être utilisé par step, ce qui demande à chaque step de faire la vérification steps.filter.outputs.frontend == 'true', mais permet une plus grande souplesse. Il reste tout à fait possible de placer la vérification au niveau du job et non de la step. Voir [https://github.com/dorny/paths-filter?tab=readme-ov-file#conditional-execution](https://github.com/dataforgoodfr/13_brigade_coupes_rases/compare/main...chore/front/ci-setup).

### Comment tester ?
Faire une modification sur un fichier contenu dans `frontend` commit & push, puis sur un autre fichier en dehors du dossier commit & push. Observer que la chaîne de build se fait intégralement dans le premier cas mais pas le second.

### Pour faciliter la validation de ma PR
- [x] Les pre-commit passent
- [x] Les test unitaires passent
- [x] Le code modifié fonctionne en local/dev
- [x] J'ai demandé une peer-review à un autre bénévole du projet
- [x] La PR est bien formattée et respecte les conventions de style
- [x] J'ai documenté les modifications apportées (dans le README.md, code ou dans un fichier spécifique si nécessaire)

### Auteur(s)
- [x] ihippocrate (GitHub ID)

### Peer Reviewer(s)
- [x] sbailleul (GitHub ID)
