### PR TITLE
Fix: Set proper working directory for 'docker compose backend make help'

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
         - pgadmin-data:/var/lib/pgadmin
   backend:
     platform: ${BACKEND_DOCKER_DEFAULT_PLATFORM}
+    working_dir: /app/backend
     build:
       target: development
       context: backend


### PR DESCRIPTION
### Description
Nocodb : _insérer le lien vers la tâche Nocodb correspondante_

_Merci de fournir une description détaillée de la tâche._

### Comment tester ?
```
docker compose up
docker compose backend make help
```
Avant il echouait comme le working directory n'était pas le bon.

### Pour faciliter la validation de ma PR
- [ ] Les pre-commit passent
- [ ] Les test unitaires passent
- [ ] Le code modifié fonctionne en local/dev
- [ ] J'ai demandé une peer-review à un autre bénévole du projet
- [ ] La PR est bien formatée et respecte les conventions de style
- [ ] J'ai documenté les modifications apportées (dans le README.md, code ou dans un fichier spécifique si nécessaire)

### Auteur(s)
- [ ] Nom Prénom (GitHub ID)

### Peer Reviewer(s)
- [ ] Nom Prénom (GitHub ID)
