### PR TITLE
Fix: use docker compose networking to access db

### DIFF
--- a/backend/.devcontainer/devcontainer.json
+++ b/backend/.devcontainer/devcontainer.json
@@ -5,10 +5,6 @@
 	"service": "backend",
 	"workspaceFolder": "/app/backend",
 	"remoteUser": "devuser",
-	"containerEnv": {
-		"DATABASE_URL": "postgresql://devuser:devuser@host.docker.internal:5432/local",
-		"ENVIRONMENT": "development"
-	},
 	"postCreateCommand": "make devserver",
 	"customizations": {
 		"vscode": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     depends_on:
       - db
     environment:
-      DATABASE_URL: postgresql://devuser:devuser@host.docker.internal:5432/local
+      DATABASE_URL: postgresql://devuser:devuser@db:5432/local
       ENVIRONMENT: development
 
   frontend:


### PR DESCRIPTION
### Description
Recent changes to docker infra breaks with old .venv installation and docker internal networking did not work. 

Fix: 
Manually remove .venv
Add link to docker compose db

### Comment tester ?
```
docker compose down
docker image rm coupes_rases-backend # ensure rebuild image
rm -rf backend/.venv # docker now uses devuser so remove old root owned files
docker compose build backend 
docker compose up 
# in vscode
# Dev containers: attach running container => backend
cd backend
make upgrade-db
make test
```
