### PR TITLE
Fix installation of backend dependencies

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,9 +16,13 @@ RUN  poetry install --without dev --no-root
 
 FROM builder as development 
 
-RUN  poetry install && useradd -ms /bin/bash devuser && chown -R devuser ./ 
+RUN  useradd -ms /bin/bash devuser \
+        && chown -R devuser ./ \
+        && chown -R devuser /tmp/poetry_cache 
 
 USER devuser
+
+RUN  poetry install
 
 FROM python:3.11-slim-buster as runtime
 


### PR DESCRIPTION
### Description

L'installation des dépendances Python à l'intérieur du container backend échoue.

```bash
docker compose exec backend bash
make install-dev-dependencies
(...)
All attempts to connect to pypi.org failed.
```
C'est parce que le répertoire de cache de poetry a pour propriétaire l'utilisateur root, alors que les commandes a l'intérieur du container sont lancée par l'utilisateur devuser


### Comment tester ?

```bash
docker compose exec backend bash
make install-dev-dependencies
```

### Pour faciliter la validation de ma PR
- [X] Les pre-commit passent
- [X] Les test unitaires passent
- [X] Le code modifié fonctionne en local/dev
- [X] J'ai demandé une peer-review à un autre bénévole du projet
- [X] La PR est bien formatée et respecte les conventions de style
- [ ] J'ai documenté les modifications apportées (dans le README.md, code ou dans un fichier spécifique si nécessaire)

### Auteur(s)
- [ ] Le Merrer Pascal (PascalLeMerrer)

### Peer Reviewer(s)
- [ ] Nom Prénom (GitHub ID)
