### PR TITLE
fix: adjust 'clearCutFormRegulationSchema' Zod schema so that it accepts null values

### DIFF
--- a/frontend/src/features/clear-cut/store/clear-cuts.ts
+++ b/frontend/src/features/clear-cut/store/clear-cuts.ts
@@ -157,9 +157,9 @@ const clearCutFormActorsSchema = z.object({
 })
 
 const clearCutFormRegulationSchema = z.object({
-	isPefcFscCertified: z.boolean().optional(),
-	isOver20Ha: z.boolean().optional(),
-	isPsgRequiredPlot: z.boolean().optional()
+	isPefcFscCertified: z.boolean().nullable().optional().prefault(null),
+	isOver20Ha: z.boolean().nullable().optional().prefault(null),
+	isPsgRequiredPlot: z.boolean().nullable().optional().prefault(null)
 })
 
 const clearCutFormLegalStrategySchema = z.object({


### PR DESCRIPTION
### Description
Nocodb :

Resolves #197. Fixe le problème de validation du formulaire de coupe rase lorsqu'on sélectionne "Pas d'informations" dans l'onglet "Réglementations".

### Comment tester ?
Remplir la section "Réglementations" d'une fiche de signalement de coupe rase en sélectionnant "Pas d'informations" pour au moins l'un des trois champs puis cliquer sur "Valider". La validation se déroule sans encombre, alors que précédemment l'utilisateur voyait un message d'erreur apparaître.

### Pour faciliter la validation de ma PR
- [x] Les pre-commit passent
- [x] Les test unitaires passent
- [x] Le code modifié fonctionne en local/dev
- [x] J'ai demandé une peer-review à un autre bénévole du projet
- [x] La PR est bien formatée et respecte les conventions de style
- [x] J'ai documenté les modifications apportées (dans le README.md, code ou dans un fichier spécifique si nécessaire)

### Auteur(s)
- [x] Scarpa Florent (FS-CS)

### Peer Reviewer(s)
- [x] Lamoureux Marion (marionlamoureux)
