### PR TITLE
fix: remove join on user table in 'find_clear_cut_form_by_report_id' function that filters out all relevant results

### DIFF
--- a/backend/app/services/clear_cut_form.py
+++ b/backend/app/services/clear_cut_form.py
@@ -112,7 +112,6 @@ def find_clear_cut_form_by_report_id(
     forms = (
         db.query(ClearCutForm)
         .join(ClearCutReport)
-        .join(User)
         .filter(ClearCutForm.report_id == report_id)
         .order_by(ClearCutForm.created_at.desc())
         .offset(page * size)


### PR DESCRIPTION
### Description

Fixes issue #179 ; when users save a form, the results are not persisted in the front. The issue is not that form edits are not saved, but that the function that retrieves those form edit states from the database returns nothing, due to a faulty join with the 'users' table. Removing this join allows the app to work as expected and display all results as per the latest form edition, whether one jumps between forms, refreshes the page or even logs out.

Only potential drawbacks are:
- Multiple form states, even identical, can coexist in the database. Only the latest one is shown in the interface. There is no limit on the number of states coexisting for a single form, but under normal use the volume should not blow up.
- Access to reading and editing a form is not restricted by user/role. Under the premice that only one volunteer works at a time on a form and that everyone having access to the app are trained volunteers with no malicious intent, this should not be a problem. Moreover, since every edit is saved in the database with its editor ID and timestamp, form states are versioned.

### Comment tester ?
Before this code update, filling a form in the frontend interface and then saving it results in the form returning to its empty state.

After the update, saving results shows them being persisted in the form, regardless of user interactions with the app (jumping between forms, refreshing the page, logging out..)

### Pour faciliter la validation de ma PR
- [x] Les pre-commit passent
- [x] Les test unitaires passent
- [x] Le code modifié fonctionne en local/dev
- [x] J'ai demandé une peer-review à un autre bénévole du projet
- [x] La PR est bien formatée et respecte les conventions de style
- [x] J'ai documenté les modifications apportées (dans le README.md, code ou dans un fichier spécifique si nécessaire)

### Auteur(s)
- [x] Florent Scarpa (FS-CS)

### Peer Reviewer(s)
- [x] Marion Lamoureux (marionlamoureux)
