### PR TITLE
feat(airtable): sync PostgreSQL vers Airtable via APScheduler

### DIFF
--- a/airtable_sync/requirements.txt
+++ b/airtable_sync/requirements.txt
@@ -1,0 +1,2 @@
+psycopg2-binary==2.9.10
+pyairtable==2.3.3

--- a/airtable_sync/sync.py
+++ b/airtable_sync/sync.py
@@ -1,0 +1,154 @@
+"""Sync PostgreSQL tables clear_cuts_reports and users to Airtable."""
+
+import os
+import sys
+
+import psycopg2
+import psycopg2.extras
+from pyairtable import Api
+
+DATABASE_URL = os.environ["DATABASE_URL"]
+AIRTABLE_TOKEN = os.environ["AIRTABLE_TOKEN"]
+AIRTABLE_BASE_ID = os.environ["AIRTABLE_BASE_ID"]
+
+USERS_TABLE = "Users"
+REPORTS_TABLE = "ClearCutReports"
+
+AIRTABLE_BATCH_SIZE = 10
+
+
+def get_connection():
+    return psycopg2.connect(DATABASE_URL, cursor_factory=psycopg2.extras.RealDictCursor)
+
+
+def fetch_users(conn):
+    with conn.cursor() as cur:
+        cur.execute("""
+            SELECT
+                id,
+                first_name,
+                last_name,
+                login,
+                email,
+                role,
+                is_active,
+                created_at::text,
+                updated_at::text
+            FROM users
+            WHERE deleted_at IS NULL
+            ORDER BY id
+        """)
+        return cur.fetchall()
+
+
+def fetch_reports(conn):
+    with conn.cursor() as cur:
+        cur.execute("""
+            SELECT
+                r.id,
+                r.status,
+                r.slope_area_hectare,
+                r.total_area_hectare,
+                r.total_ecological_zoning_area_hectare,
+                r.first_cut_date::text,
+                r.last_cut_date::text,
+                r.created_at::text,
+                r.updated_at::text,
+                c.name                  AS city,
+                d.code                  AS department_code,
+                d.name                  AS department_name,
+                u.login                 AS assigned_to,
+                arb.login               AS assignment_requested_by
+            FROM clear_cuts_reports r
+            LEFT JOIN cities       c   ON r.city_id                    = c.id
+            LEFT JOIN departments  d   ON c.department_id              = d.id
+            LEFT JOIN users        u   ON r.user_id                    = u.id
+            LEFT JOIN users        arb ON r.assignment_requested_by_id = arb.id
+            ORDER BY r.id
+        """)
+        return cur.fetchall()
+
+
+def to_fields(row):
+    """Convert a psycopg2 RealDictRow to a plain dict with Airtable-safe values."""
+    fields = {}
+    for key, value in row.items():
+        if value is None:
+            continue
+        if isinstance(value, bool):
+            fields[key] = value
+        elif isinstance(value, (int, float)):
+            fields[key] = value
+        else:
+            fields[key] = str(value)
+    return fields
+
+
+def sync_table(table, pg_rows):
+    """Upsert PostgreSQL rows into Airtable and delete removed rows."""
+    # Index existing Airtable records by their pg id
+    existing = {
+        int(rec["fields"]["id"]): rec["id"]
+        for rec in table.all(fields=["id"])
+        if "id" in rec["fields"]
+    }
+
+    pg_ids = {row["id"] for row in pg_rows}
+    to_create = []
+    to_update = []
+
+    for row in pg_rows:
+        fields = to_fields(row)
+        pg_id = row["id"]
+        if pg_id in existing:
+            to_update.append({"id": existing[pg_id], "fields": fields})
+        else:
+            to_create.append(fields)
+
+    to_delete = [
+        airtable_id
+        for pg_id, airtable_id in existing.items()
+        if pg_id not in pg_ids
+    ]
+
+    for i in range(0, len(to_create), AIRTABLE_BATCH_SIZE):
+        table.batch_create(to_create[i : i + AIRTABLE_BATCH_SIZE])
+
+    for i in range(0, len(to_update), AIRTABLE_BATCH_SIZE):
+        table.batch_update(to_update[i : i + AIRTABLE_BATCH_SIZE])
+
+    for i in range(0, len(to_delete), AIRTABLE_BATCH_SIZE):
+        table.batch_delete(to_delete[i : i + AIRTABLE_BATCH_SIZE])
+
+    return len(to_create), len(to_update), len(to_delete)
+
+
+def main():
+    api = Api(AIRTABLE_TOKEN)
+    users_table = api.table(AIRTABLE_BASE_ID, USERS_TABLE)
+    reports_table = api.table(AIRTABLE_BASE_ID, REPORTS_TABLE)
+
+    with get_connection() as conn:
+        print("Fetching data from PostgreSQL…")
+        users = fetch_users(conn)
+        reports = fetch_reports(conn)
+
+    print(f"  {len(users)} users, {len(reports)} reports to sync")
+
+    print("Syncing Users…")
+    created, updated, deleted = sync_table(users_table, users)
+    print(f"  created={created}  updated={updated}  deleted={deleted}")
+
+    print("Syncing ClearCutReports…")
+    created, updated, deleted = sync_table(reports_table, reports)
+    print(f"  created={created}  updated={updated}  deleted={deleted}")
+
+    print("Sync complete.")
+
+
+if __name__ == "__main__":
+    missing = [v for v in ("DATABASE_URL", "AIRTABLE_TOKEN", "AIRTABLE_BASE_ID") if not os.environ.get(v)]
+    if missing:
+        print(f"Missing environment variables: {', '.join(missing)}", file=sys.stderr)
+        sys.exit(1)
+    main()

--- a/backend/app/services/airtable_sync.py
+++ b/backend/app/services/airtable_sync.py
@@ -1,0 +1,116 @@
+import logging
+import os
+
+from pyairtable import Api
+from sqlalchemy.orm import Session, joinedload
+
+from app.models import City, ClearCutReport, User
+
+logger = logging.getLogger(__name__)
+
+AIRTABLE_TOKEN = os.getenv("AIRTABLE_TOKEN", "")
+AIRTABLE_BASE_ID = os.getenv("AIRTABLE_BASE_ID", "")
+USERS_TABLE = "Users"
+REPORTS_TABLE = "ClearCutReports"
+BATCH_SIZE = 10
+
+
+def _to_fields(row: dict) -> dict:
+    return {
+        k: (v if isinstance(v, (bool, int, float)) else str(v))
+        for k, v in row.items()
+        if v is not None
+    }
+
+
+def _sync_table(table, rows: list[dict]) -> tuple[int, int, int]:
+    existing = {
+        int(rec["fields"]["id"]): rec["id"]
+        for rec in table.all(fields=["id"])
+        if "id" in rec["fields"]
+    }
+    pg_ids = {row["id"] for row in rows}
+    to_create, to_update = [], []
+
+    for row in rows:
+        fields = _to_fields(row)
+        if row["id"] in existing:
+            to_update.append({"id": existing[row["id"]], "fields": fields})
+        else:
+            to_create.append(fields)
+
+    to_delete = [aid for pg_id, aid in existing.items() if pg_id not in pg_ids]
+
+    for i in range(0, len(to_create), BATCH_SIZE):
+        table.batch_create(to_create[i : i + BATCH_SIZE])
+    for i in range(0, len(to_update), BATCH_SIZE):
+        table.batch_update(to_update[i : i + BATCH_SIZE])
+    for i in range(0, len(to_delete), BATCH_SIZE):
+        table.batch_delete(to_delete[i : i + BATCH_SIZE])
+
+    return len(to_create), len(to_update), len(to_delete)
+
+
+def _user_row(u: User) -> dict:
+    return {
+        "id": u.id,
+        "first_name": u.first_name,
+        "last_name": u.last_name,
+        "login": u.login,
+        "email": u.email,
+        "role": u.role,
+        "is_active": u.is_active,
+        "created_at": u.created_at.isoformat() if u.created_at else None,
+        "updated_at": u.updated_at.isoformat() if u.updated_at else None,
+    }
+
+
+def _report_row(r: ClearCutReport) -> dict:
+    dept = r.city.department if r.city else None
+    return {
+        "id": r.id,
+        "status": r.status,
+        "slope_area_hectare": r.slope_area_hectare,
+        "total_area_hectare": r.total_area_hectare,
+        "total_ecological_zoning_area_hectare": r.total_ecological_zoning_area_hectare,
+        "first_cut_date": r.first_cut_date.isoformat() if r.first_cut_date else None,
+        "last_cut_date": r.last_cut_date.isoformat() if r.last_cut_date else None,
+        "created_at": r.created_at.isoformat() if r.created_at else None,
+        "updated_at": r.updated_at.isoformat() if r.updated_at else None,
+        "city": r.city.name if r.city else None,
+        "department_code": dept.code if dept else None,
+        "department_name": dept.name if dept else None,
+        "assigned_to": r.user.login if r.user else None,
+        "assignment_requested_by": r.assignment_requested_by.login if r.assignment_requested_by else None,
+    }
+
+
+def sync_data_with_airtable(db: Session) -> None:
+    if not AIRTABLE_TOKEN or not AIRTABLE_BASE_ID:
+        logger.warning("AIRTABLE_TOKEN or AIRTABLE_BASE_ID not set, skipping sync")
+        return
+
+    logger.info("Starting Airtable sync…")
+    try:
+        api = Api(AIRTABLE_TOKEN)
+
+        users = db.query(User).filter(User.deleted_at.is_(None)).order_by(User.id).all()
+        c, u, d = _sync_table(api.table(AIRTABLE_BASE_ID, USERS_TABLE), [_user_row(u) for u in users])
+        logger.info("Users: created=%d updated=%d deleted=%d", c, u, d)
+
+        reports = (
+            db.query(ClearCutReport)
+            .options(
+                joinedload(ClearCutReport.city).joinedload(City.department),
+                joinedload(ClearCutReport.user),
+                joinedload(ClearCutReport.assignment_requested_by),
+            )
+            .order_by(ClearCutReport.id)
+            .all()
+        )
+        c, u, d = _sync_table(api.table(AIRTABLE_BASE_ID, REPORTS_TABLE), [_report_row(r) for r in reports])
+        logger.info("ClearCutReports: created=%d updated=%d deleted=%d", c, u, d)
+
+        logger.info("Airtable sync complete")
+    except Exception:
+        logger.exception("Airtable sync failed")

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -1,0 +1,33 @@
+import logging
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+from app.database import SessionLocal
+from app.services.airtable_sync import sync_data_with_airtable
+
+logger = logging.getLogger(__name__)
+scheduler = BackgroundScheduler()
+
+def scheduled_airtable_sync():
+    logger.info("Executing scheduled Airtable sync job...")
+    db = SessionLocal()
+    try:
+        sync_data_with_airtable(db)
+    finally:
+        db.close()
+
+def start_scheduler():
+    if not scheduler.running:
+        # Schedule at 8:00 and 12:00 every day
+        scheduler.add_job(
+            scheduled_airtable_sync,
+            trigger=CronTrigger(hour="8,14", minute="0", timezone="Europe/Paris"),
+            id="airtable_sync_job",
+            replace_existing=True,
+        )
+        scheduler.start()
+        logger.info("Background scheduler started. Airtable sync scheduled for 8:00 and 14:00 (Europe/Paris).")
+
+def stop_scheduler():
+    if scheduler.running:
+        scheduler.shutdown()
+        logger.info("Background scheduler stopped.")


### PR DESCRIPTION
- Implémente airtable_sync.py dans le backend (SQLAlchemy + pyairtable)
- Synchronise les tables users et clear_cuts_reports vers Airtable
- Upsert par id PostgreSQL, suppression des lignes retirées
- Scheduler à 8h00 et 14h00 heure française (Europe/Paris)
- Variables d'env requises sur Clever Cloud : AIRTABLE_TOKEN, AIRTABLE_BASE_ID
- Ajoute le script standalone airtable_sync/ (usage ponctuel)

### Description
Nocodb : _insérer le lien vers la tâche Nocodb correspondante_

_Merci de fournir une description détaillée de la tâche._

### Comment tester ?
_Merci d'indiquer comment tester les modifications apportées._

### Pour faciliter la validation de ma PR
- [ ] Les pre-commit passent
- [ ] Les test unitaires passent
- [ ] Le code modifié fonctionne en local/dev
- [ ] J'ai demandé une peer-review à un autre bénévole du projet
- [ ] La PR est bien formatée et respecte les conventions de style
- [ ] J'ai documenté les modifications apportées (dans le README.md, code ou dans un fichier spécifique si nécessaire)

### Auteur(s)
- [ ] Nom Prénom (GitHub ID)

### Peer Reviewer(s)
- [ ] Nom Prénom (GitHub ID)
