### PR TITLE
feat(workflow): ajout validation benevole et corrections mobile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,6 +169,9 @@ cython_debug/
 # Test db sqlite file
 backend/test.db
 
+# Local dev photo uploads (fallback when S3 not configured)
+backend/uploads/
+
 env311
 
 # Documentation et Notes d'Agent Local

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -233,6 +233,7 @@ class EcologicalZoning(Base):
 
 CLEARCUT_STATUSES = [
     "to_validate",
+    "in_progress",
     "waiting_for_validation",
     "legal_validated",
     "validated",

--- a/backend/app/routes/clear_cuts_reports.py
+++ b/backend/app/routes/clear_cuts_reports.py
@@ -31,6 +31,7 @@ from app.services.clear_cut_report import (
     update_clear_cut_report,
     volunteer_create_clear_cut_report,
 )
+from app.services.email import send_validation_rejected_email
 from app.services.user_auth import get_current_user, get_optional_current_user
 
 logger = getLogger(__name__)
@@ -244,6 +245,8 @@ def approve_assignment(
         )
     report.user_id = report.assignment_requested_by_id
     report.assignment_requested_by_id = None
+    if report.status == "to_validate":
+        report.status = "in_progress"
     db.commit()
     return {"message": "Assignment approved"}
 
@@ -300,8 +303,108 @@ def unassign_report_from_me(
             detail="You are not assigned to this report",
         )
     report.user_id = None
+    if report.status == "in_progress":
+        report.status = "to_validate"
     db.commit()
     return {"message": "Unassigned successfully"}
+
+
+@router.post(
+    "/{report_id}/volunteer-validate",
+    status_code=status.HTTP_200_OK,
+)
+def volunteer_validate(
+    report_id: int,
+    user: User = Depends(get_current_user),
+    db: Session = db_session,
+):
+    """Volunteer marks the form as complete and requests admin validation."""
+    report = db.query(ClearCutReport).filter(ClearCutReport.id == report_id).first()
+    if not report:
+        raise AppHTTPException(
+            status_code=404, type="NOT_FOUND", detail="Report not found"
+        )
+    if user.role == "volunteer" and report.user_id != user.id:
+        raise AppHTTPException(
+            status_code=403,
+            type="FORBIDDEN",
+            detail="You are not assigned to this report",
+        )
+    if report.status != "in_progress":
+        raise AppHTTPException(
+            status_code=400,
+            type="INVALID_STATUS",
+            detail="Report must be in_progress to be submitted for validation",
+        )
+    report.status = "waiting_for_validation"
+    db.commit()
+    return {"message": "Validation request submitted"}
+
+
+@router.post(
+    "/{report_id}/approve-validation",
+    status_code=status.HTTP_200_OK,
+)
+def approve_validation(
+    report_id: int,
+    user: User = Depends(get_current_user),
+    db: Session = db_session,
+):
+    """Admin approves the volunteer's validation request."""
+    if user.role != "admin":
+        raise AppHTTPException(
+            status_code=403,
+            type="FORBIDDEN",
+            detail="Only admins can approve validations",
+        )
+    report = db.query(ClearCutReport).filter(ClearCutReport.id == report_id).first()
+    if not report:
+        raise AppHTTPException(
+            status_code=404, type="NOT_FOUND", detail="Report not found"
+        )
+    if report.status != "waiting_for_validation":
+        raise AppHTTPException(
+            status_code=400,
+            type="INVALID_STATUS",
+            detail="Report must be waiting_for_validation to be approved",
+        )
+    report.status = "validated"
+    db.commit()
+    return {"message": "Validation approved"}
+
+
+@router.post(
+    "/{report_id}/reject-validation",
+    status_code=status.HTTP_200_OK,
+)
+def reject_validation(
+    report_id: int,
+    user: User = Depends(get_current_user),
+    db: Session = db_session,
+):
+    """Admin rejects the volunteer's validation request and notifies the volunteer."""
+    if user.role != "admin":
+        raise AppHTTPException(
+            status_code=403,
+            type="FORBIDDEN",
+            detail="Only admins can reject validations",
+        )
+    report = db.query(ClearCutReport).filter(ClearCutReport.id == report_id).first()
+    if not report:
+        raise AppHTTPException(
+            status_code=404, type="NOT_FOUND", detail="Report not found"
+        )
+    if report.status != "waiting_for_validation":
+        raise AppHTTPException(
+            status_code=400,
+            type="INVALID_STATUS",
+            detail="Report must be waiting_for_validation to be rejected",
+        )
+    report.status = "in_progress"
+    db.commit()
+    if report.user and report.user.email:
+        send_validation_rejected_email(report.user.email, report_id)
+    return {"message": "Validation rejected"}
 
 
 @router.get(

--- a/backend/app/routes/images.py
+++ b/backend/app/routes/images.py
@@ -1,21 +1,47 @@
 from logging import getLogger
+from pathlib import Path
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
+from fastapi.responses import FileResponse
 
 from app.common.errors import AppHTTPException
+from app.config import settings
 from app.schemas.base import BaseSchema
 from app.schemas.image_upload import ImageUploadRequest, ImageUploadResponse
 from app.services.s3 import s3_service
-from app.services.user_auth import get_current_user
+from app.services.user_auth import get_current_user, get_optional_current_user
 
 logger = getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/images", tags=["Images"])
 
+LOCAL_UPLOADS_PATH = Path("/app/uploads")
+
+ALLOWED_TYPES = ["image/jpeg", "image/jpg", "image/png", "image/gif", "image/webp"]
+
+EXTENSION_TO_MIME = {
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "png": "image/png",
+    "gif": "image/gif",
+    "webp": "image/webp",
+    "heic": "image/jpeg",
+    "heif": "image/jpeg",
+}
+
+
+def infer_content_type(filename: str, declared: str) -> str:
+    if declared and declared in ALLOWED_TYPES:
+        return declared
+    ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+    return EXTENSION_TO_MIME.get(ext, declared or "image/jpeg")
+
+
+def is_s3_configured() -> bool:
+    return bool(settings.S3_ACCESS_KEY_ID and settings.S3_SECRET_ACCESS_KEY)
+
 
 class ImageViewResponse(BaseSchema):
-    """Response schema for image viewing URL"""
-
     view_url: str
     expires_in: int
 
@@ -26,47 +52,53 @@ class ImageViewResponse(BaseSchema):
     response_model_exclude_none=True,
 )
 def generate_upload_url(
-    request: ImageUploadRequest,
+    request: Request,
+    upload_request: ImageUploadRequest,
     _=Depends(get_current_user),
 ):
-    """
-    Generate a pre-signed URL for uploading an image to S3
+    content_type = infer_content_type(upload_request.filename, upload_request.content_type)
 
-    The frontend can use this URL to upload the image directly to S3.
-    """
-    try:
-        # Validate content type
-        allowed_types = [
-            "image/jpeg",
-            "image/jpg",
-            "image/png",
-            "image/gif",
-            "image/webp",
-        ]
-        if request.content_type not in allowed_types:
-            raise AppHTTPException(
-                status_code=400,
-                type="INVALID_CONTENT_TYPE",
-                detail=f"Content type {request.content_type} not allowed. Allowed types: {allowed_types}",
-            )
-
-        # Set file size limit based on content type
-        max_size = 10 * 1024 * 1024  # 10MB for images
-        if request.file_size and request.file_size > max_size:
-            raise HTTPException(
-                status_code=400,
-                type="FILE_SIZE_EXCEDEED",
-                detail=f"File size {request.file_size} exceeds maximum allowed size of {max_size} bytes",
-            )
-
-        # Generate pre-signed URL
-        result = s3_service.generate_presigned_upload_url(
-            filename=request.filename,
-            content_type=request.content_type,
-            report_id=request.report_id,
-            max_file_size=max_size,
+    if content_type not in ALLOWED_TYPES:
+        raise AppHTTPException(
+            status_code=400,
+            type="INVALID_CONTENT_TYPE",
+            detail=f"Type de fichier non autorisé. Types acceptés : {ALLOWED_TYPES}",
         )
 
+    max_size = 10 * 1024 * 1024
+    if upload_request.file_size and upload_request.file_size > max_size:
+        raise AppHTTPException(
+            status_code=400,
+            type="FILE_SIZE_EXCEEDED",
+            detail=f"Fichier trop volumineux ({upload_request.file_size} octets). Taille maximale : {max_size} octets.",
+        )
+
+    if not is_s3_configured():
+        import uuid as uuid_module
+
+        file_id = str(uuid_module.uuid4())
+        filename = upload_request.filename or "photo.jpg"
+        if upload_request.report_id:
+            key = f"local/reports/{upload_request.report_id}/{file_id}_{filename}"
+        else:
+            key = f"local/{file_id}_{filename}"
+
+        base_url = str(request.base_url).rstrip("/")
+        return ImageUploadResponse(
+            upload_url=f"{base_url}/api/v1/images/local-upload",
+            fields={"key": key, "Content-Type": content_type},
+            file_url=f"{base_url}/api/v1/images/local/{key}",
+            expires_in=3600,
+            key=key,
+        )
+
+    try:
+        result = s3_service.generate_presigned_upload_url(
+            filename=upload_request.filename,
+            content_type=content_type,
+            report_id=upload_request.report_id,
+            max_file_size=max_size,
+        )
         return ImageUploadResponse(
             upload_url=result["upload_url"],
             fields=result["fields"],
@@ -74,12 +106,36 @@ def generate_upload_url(
             expires_in=result["expires_in"],
             key=result["key"],
         )
-
     except Exception as e:
         logger.error(f"Failed to generate upload URL: {str(e)}")
         raise AppHTTPException(
-            status_code=500, detail="Failed to generate upload URL"
+            status_code=500, detail="Impossible de générer l'URL d'upload."
         ) from e
+
+
+@router.post("/local-upload", status_code=204)
+async def local_upload(
+    key: str = Form(...),
+    file: UploadFile = File(...),
+):
+    """Fallback local file storage — utilisé uniquement en développement quand S3 n'est pas configuré."""
+    relative_key = key.removeprefix("local/")
+    file_path = LOCAL_UPLOADS_PATH / relative_key
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    content = await file.read()
+    file_path.write_bytes(content)
+
+
+@router.get("/local/{key:path}")
+async def get_local_file(
+    key: str,
+    _=Depends(get_optional_current_user),
+):
+    """Sert les fichiers uploadés localement en développement."""
+    file_path = LOCAL_UPLOADS_PATH / key.removeprefix("local/")
+    if not file_path.exists():
+        raise HTTPException(status_code=404, detail="Fichier non trouvé")
+    return FileResponse(file_path)
 
 
 @router.get(
@@ -88,28 +144,28 @@ def generate_upload_url(
     response_model_exclude_none=True,
 )
 def generate_view_url(
+    request: Request,
     s3_key: str,
     _=Depends(get_current_user),
 ):
-    """
-    Generate a pre-signed URL for viewing an image from S3
+    if s3_key.startswith("local/"):
+        base_url = str(request.base_url).rstrip("/")
+        # strip the "local/" prefix so the URL path is /local/{relative_path}
+        # matching how the file was actually saved (without the "local/" directory)
+        relative = s3_key.removeprefix("local/")
+        return ImageViewResponse(
+            view_url=f"{base_url}/api/v1/images/local/{relative}",
+            expires_in=3600,
+        )
 
-    The s3_key should be the full S3 key path (e.g., "development/reports/123/uuid_image.jpg")
-    """
     try:
-        expires_in = 3600  # 1 hour
         view_url = s3_service.generate_presigned_get_url(
             s3_key=s3_key,
-            expires_in=expires_in,
+            expires_in=3600,
         )
-
-        return ImageViewResponse(
-            view_url=view_url,
-            expires_in=expires_in,
-        )
-
+        return ImageViewResponse(view_url=view_url, expires_in=3600)
     except Exception as e:
         logger.error(f"Failed to generate view URL for {s3_key}: {str(e)}")
         raise HTTPException(
-            status_code=500, detail="Failed to generate view URL"
+            status_code=500, detail="Impossible de générer l'URL de visualisation."
         ) from e

--- a/backend/app/routes/images.py
+++ b/backend/app/routes/images.py
@@ -1,5 +1,6 @@
 from logging import getLogger
 from pathlib import Path
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
 from fastapi.responses import FileResponse
@@ -56,7 +57,9 @@ def generate_upload_url(
     upload_request: ImageUploadRequest,
     _=Depends(get_current_user),
 ):
-    content_type = infer_content_type(upload_request.filename, upload_request.content_type)
+    content_type = infer_content_type(
+        upload_request.filename, upload_request.content_type
+    )
 
     if content_type not in ALLOWED_TYPES:
         raise AppHTTPException(
@@ -115,8 +118,8 @@ def generate_upload_url(
 
 @router.post("/local-upload", status_code=204)
 async def local_upload(
-    key: str = Form(...),
-    file: UploadFile = File(...),
+    key: Annotated[str, Form()],
+    file: Annotated[UploadFile, File()],
 ):
     """Fallback local file storage — utilisé uniquement en développement quand S3 n'est pas configuré."""
     relative_key = key.removeprefix("local/")

--- a/backend/app/services/clear_cut_form.py
+++ b/backend/app/services/clear_cut_form.py
@@ -35,6 +35,15 @@ def add_clear_cut_form_entry(
     new_version: ClearCutFormCreate,
     etag: str | None,
 ) -> ClearCutForm:
+    report = db.get(ClearCutReport, report_id)
+    locked_statuses = ("waiting_for_validation", "validated", "legal_validated", "final_validated")
+    if report is not None and editor.role == "volunteer" and report.status in locked_statuses:
+        raise AppHTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            type="FORM_LOCKED",
+            detail="Le formulaire est verrouillé après validation. Seul un administrateur peut le modifier.",
+        )
+
     last_form = find_last_clear_cut_form_by_report_id(db, report_id)
     new_clear_cut_form_entry = clear_cut_form_create_to_clear_cut_form(
         new_version, editor, report_id
@@ -95,20 +104,6 @@ def add_clear_cut_form_entry(
             new_clear_cut_form_entry.request_engaged = last_form_entry.request_engaged
 
     db.add(new_clear_cut_form_entry)
-
-    # Update report status when form is submitted
-    report = db.get(ClearCutReport, report_id)
-    if report is not None and report.status == "to_validate":
-        report.status = (
-            "validated" if editor.role == "admin" else "waiting_for_validation"
-        )
-    elif (
-        report is not None
-        and report.status == "waiting_for_validation"
-        and editor.role == "admin"
-    ):
-        report.status = "validated"
-
     db.commit()
     db.refresh(new_clear_cut_form_entry)
     return new_clear_cut_form_entry

--- a/backend/app/services/clear_cut_form.py
+++ b/backend/app/services/clear_cut_form.py
@@ -36,8 +36,17 @@ def add_clear_cut_form_entry(
     etag: str | None,
 ) -> ClearCutForm:
     report = db.get(ClearCutReport, report_id)
-    locked_statuses = ("waiting_for_validation", "validated", "legal_validated", "final_validated")
-    if report is not None and editor.role == "volunteer" and report.status in locked_statuses:
+    locked_statuses = (
+        "waiting_for_validation",
+        "validated",
+        "legal_validated",
+        "final_validated",
+    )
+    if (
+        report is not None
+        and editor.role == "volunteer"
+        and report.status in locked_statuses
+    ):
         raise AppHTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             type="FORM_LOCKED",

--- a/backend/app/services/clear_cut_report.py
+++ b/backend/app/services/clear_cut_report.py
@@ -289,17 +289,6 @@ def volunteer_create_clear_cut_report(
 def update_clear_cut_report(
     id: int, db: Session, connected_user: User, request: ClearCutReportPutRequestSchema
 ):
-    user_id = None
-    if connected_user.role == "volunteer":
-        if request.user_id is not None and request.user_id != connected_user.id:
-            raise AppHTTPException(
-                status_code=403,
-                type="INVALID_REQUESTER_RIGHTS",
-                detail="Volunteer could not assign an other user",
-            )
-        user_id = connected_user.id
-    if connected_user.role == "admin":
-        user_id = request.user_id
     report = db.get(ClearCutReport, id)
     if not report:
         raise AppHTTPException(
@@ -308,9 +297,20 @@ def update_clear_cut_report(
             detail="Clear cut report not found",
         )
 
-    report.user_id = user_id
-    if user_id is not None:
-        report.assignment_requested_by_id = None
+    # Only update user_id when explicitly included in the request body
+    if "user_id" in request.model_fields_set:
+        if connected_user.role == "volunteer":
+            if request.user_id is not None and request.user_id != connected_user.id:
+                raise AppHTTPException(
+                    status_code=403,
+                    type="INVALID_REQUESTER_RIGHTS",
+                    detail="Volunteer could not assign an other user",
+                )
+            report.user_id = connected_user.id
+        if connected_user.role == "admin":
+            report.user_id = request.user_id
+        if report.user_id is not None:
+            report.assignment_requested_by_id = None
 
     if request.status is not None:
         if connected_user.role == "admin":
@@ -348,6 +348,7 @@ def find_clearcuts_reports(
         query = query.filter(
             or_(
                 ClearCutReport.status == "to_validate",
+                ClearCutReport.status == "waiting_for_validation",
                 ClearCutReport.assignment_requested_by_id.is_not(None),
             )
         )

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -11,6 +11,16 @@ def send_assignment_email(user_email: str, coupe_id: int):
     print(f"EMAIL SENT TO {user_email}: Vous avez été assigné à la coupe {coupe_id}.")
 
 
+def send_validation_rejected_email(user_email: str, report_id: int):
+    # Mock sending email
+    logger.info(
+        f"EMAIL SENT TO {user_email}: Votre validation de la coupe {report_id} a été refusée par un administrateur. Veuillez compléter le formulaire avant de soumettre à nouveau."
+    )
+    print(
+        f"EMAIL SENT TO {user_email}: Votre validation de la coupe {report_id} a été refusée par un administrateur. Veuillez compléter le formulaire avant de soumettre à nouveau."
+    )
+
+
 def send_reset_password_email(user_email: str, reset_token: str):
     # Mock sending email
     reset_link = f"http://localhost:8081/reset-password?token={reset_token}"

--- a/backend/test/database/test_models.py
+++ b/backend/test/database/test_models.py
@@ -70,7 +70,7 @@ def test_report_creation(db):
         )
     assert (
         str(exc_info.value)
-        == "Status must be one of: to_validate, waiting_for_validation, legal_validated, validated, final_validated, rejected"
+        == "Status must be one of: to_validate, in_progress, waiting_for_validation, legal_validated, validated, final_validated, rejected"
     )
 
     assert report.id is not None

--- a/backend/test/web_api/test_clear_cut.py
+++ b/backend/test/web_api/test_clear_cut.py
@@ -125,8 +125,8 @@ def test_get_report(client: TestClient):
 def test_affect_me_using_connected_volunteer_should_work(
     db: Session, client: TestClient
 ):
-    token = get_volunteer_user_token(client, db, "assigned-test@volunteer.com")[1]
-    updates = {}
+    [me, token] = get_volunteer_user_token(client, db, "assigned-test@volunteer.com")
+    updates = {"user_id": str(me.id)}
 
     response = client.put(
         "/api/v1/clear-cuts-reports/1",

--- a/backend/test/web_api/test_clear_cut_forms.py
+++ b/backend/test/web_api/test_clear_cut_forms.py
@@ -104,8 +104,8 @@ def test_create_version_success(client: TestClient, db: Session):
     # If your API returns workSignVisible, add it here
 
 
-def test_form_submission_updates_report_status(client: TestClient, db: Session):
-    """Test that submitting a form updates the report status from 'to_validate' to 'validated'"""
+def test_form_submission_does_not_auto_update_report_status(client: TestClient, db: Session):
+    """La soumission du formulaire ne change plus le statut : il faut passer par volunteer-validate puis approve-validation."""
     token = get_admin_user_token(client, db)[1]
 
     # Verify initial report status is "to_validate"
@@ -163,4 +163,4 @@ def test_form_submission_updates_report_status(client: TestClient, db: Session):
     updated_report_response = client.get("/api/v1/clear-cuts-reports/1")
     assert updated_report_response.status_code == status.HTTP_200_OK
     updated_report_data = updated_report_response.json()
-    assert updated_report_data["status"] == "validated"
+    assert updated_report_data["status"] == "to_validate"

--- a/backend/test/web_api/test_clear_cut_forms.py
+++ b/backend/test/web_api/test_clear_cut_forms.py
@@ -104,7 +104,9 @@ def test_create_version_success(client: TestClient, db: Session):
     # If your API returns workSignVisible, add it here
 
 
-def test_form_submission_does_not_auto_update_report_status(client: TestClient, db: Session):
+def test_form_submission_does_not_auto_update_report_status(
+    client: TestClient, db: Session
+):
     """La soumission du formulaire ne change plus le statut : il faut passer par volunteer-validate puis approve-validation."""
     token = get_admin_user_token(client, db)[1]
 

--- a/frontend/src/features/admin/components/action-required/ActionRequiredTab.tsx
+++ b/frontend/src/features/admin/components/action-required/ActionRequiredTab.tsx
@@ -1,11 +1,14 @@
 import { useNavigate } from "@tanstack/react-router"
-import { ChevronRight, FileWarning } from "lucide-react"
+import { Check, ChevronRight, FileWarning, X } from "lucide-react"
 import { useEffect } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
+	approveValidationThunk,
 	getAdminActionRequiredReportsThunk,
-	selectAdminActionRequiredReports
+	rejectValidationThunk,
+	selectAdminActionRequiredReports,
+	selectAssignation
 } from "@/features/clear-cut/store/clear-cuts-slice"
 import { UpdateUserDialog } from "@/features/admin/components/users-list/UpdateUserDialog"
 import { selectPendingUsers, useGetUsers } from "@/features/admin/store/users.slice"
@@ -17,13 +20,28 @@ export function ActionRequiredTab() {
 	const dispatch = useAppDispatch()
 	const navigate = useNavigate()
 	const reportsState = useAppSelector(selectAdminActionRequiredReports)
+	const assignation = useAppSelector(selectAssignation)
 	const pendingUsers = useAppSelector(selectPendingUsers)
-	
+
 	useGetUsers()
 
 	useEffect(() => {
 		dispatch(getAdminActionRequiredReportsThunk({ page: 0, size: 50 }))
 	}, [dispatch])
+
+	const handleApproveValidation = (e: React.MouseEvent, reportId: string) => {
+		e.stopPropagation()
+		dispatch(approveValidationThunk(reportId)).then(() => {
+			dispatch(getAdminActionRequiredReportsThunk({ page: 0, size: 50 }))
+		})
+	}
+
+	const handleRejectValidation = (e: React.MouseEvent, reportId: string) => {
+		e.stopPropagation()
+		dispatch(rejectValidationThunk(reportId)).then(() => {
+			dispatch(getAdminActionRequiredReportsThunk({ page: 0, size: 50 }))
+		})
+	}
 
 	if (reportsState.status === "idle" || reportsState.status === "loading") {
 		return (
@@ -49,6 +67,8 @@ export function ActionRequiredTab() {
 	}
 
 	const reports = reportsState.value?.content ?? []
+	const validationRequests = reports.filter((r) => r.status === "waiting_for_validation")
+	const otherActions = reports.filter((r) => r.status !== "waiting_for_validation")
 
 	return (
 		<div className="flex flex-col w-full h-full p-2 overflow-y-auto bg-white">
@@ -59,6 +79,78 @@ export function ActionRequiredTab() {
 				Signalements de nouvelles coupes à valider ou demandes d'attribution en attente.
 			</p>
 
+			{/* Validation requests from volunteers */}
+			{validationRequests.length > 0 && (
+				<div className="mb-10">
+					<h3 className="text-lg font-semibold text-neutral-800 mb-4 flex items-center gap-2">
+						<Check className="h-5 w-5 text-orange-500" />
+						Demandes de validation bénévole ({validationRequests.length})
+					</h3>
+					<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+						{validationRequests.map((report) => (
+							<div
+								key={report.id}
+								className="bg-orange-50 p-4 rounded-xl border border-orange-200 flex flex-col gap-3"
+							>
+								<div className="flex justify-between items-start">
+									<div className="flex-1 min-w-0">
+										<h3 className="font-semibold text-neutral-800 truncate">
+											{report.city || "Ville Inconnue"}
+										</h3>
+										<p className="text-xs text-neutral-500">
+											Dép. {report.department.code} · {report.totalAreaHectare?.toFixed(1) || 0} ha
+										</p>
+									</div>
+									<div className="bg-orange-400 text-white text-[10px] px-2 py-0.5 rounded font-bold uppercase ml-2 shrink-0">
+										Validation terrain
+									</div>
+								</div>
+								{report.affectedUser && (
+									<p className="text-xs text-neutral-600">
+										Bénévole : <span className="font-medium">{report.affectedUser.login}</span>
+									</p>
+								)}
+								<p className="text-xs text-neutral-500">
+									Mis à jour le {new Date(report.updatedAt).toLocaleDateString("fr-FR")}
+								</p>
+								<div className="flex gap-2 mt-1">
+									<Button
+										size="sm"
+										variant="outline"
+										className="flex-1 text-neutral-600 border-neutral-300 min-h-[40px]"
+										onClick={() => navigate({ to: `/clear-cuts/${report.id}` })}
+									>
+										Voir le formulaire
+									</Button>
+								</div>
+								<div className="flex gap-2">
+									<Button
+										size="sm"
+										className="flex-1 bg-green-600 hover:bg-green-700 text-white font-semibold min-h-[44px]"
+										disabled={assignation.status === "loading"}
+										onClick={(e) => handleApproveValidation(e, report.id)}
+									>
+										<Check className="h-4 w-4 mr-1" />
+										Approuver
+									</Button>
+									<Button
+										size="sm"
+										variant="outline"
+										className="flex-1 border-red-300 text-red-600 hover:bg-red-50 font-semibold min-h-[44px]"
+										disabled={assignation.status === "loading"}
+										onClick={(e) => handleRejectValidation(e, report.id)}
+									>
+										<X className="h-4 w-4 mr-1" />
+										Rejeter
+									</Button>
+								</div>
+							</div>
+						))}
+					</div>
+				</div>
+			)}
+
+			{/* Pending users */}
 			{pendingUsers.length > 0 && (
 				<div className="mb-10">
 					<h3 className="text-lg font-semibold text-neutral-800 mb-4 flex items-center gap-2">
@@ -94,7 +186,68 @@ export function ActionRequiredTab() {
 				</div>
 			)}
 
-			{reports.length === 0 ? (
+			{/* Other actions: new zones, assignment requests */}
+			{otherActions.length > 0 && (
+				<div className="mb-4">
+					<h3 className="text-lg font-semibold text-neutral-800 mb-4">
+						Autres actions requises ({otherActions.length})
+					</h3>
+					<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+						{otherActions.map((report) => (
+							<div
+								key={report.id}
+								className="bg-white p-5 rounded-xl shadow-sm border border-neutral-200 hover:shadow-md hover:border-primary/30 transition-all cursor-pointer flex flex-col group relative overflow-hidden"
+								onClick={() => navigate({ to: `/clear-cuts/${report.id}` })}
+							>
+								{report.status === "to_validate" && !report.assignmentRequestedById && (
+									<div className="absolute top-0 right-0 bg-red-500 text-white text-[10px] px-2 py-1 rounded-bl-lg font-bold uppercase tracking-wider">
+										Nouvelle Zone
+									</div>
+								)}
+								{report.assignmentRequestedById && (
+									<div className="absolute top-0 right-0 bg-amber-500 text-white text-[10px] px-2 py-1 rounded-bl-lg font-bold uppercase tracking-wider">
+										Demande Attribution
+									</div>
+								)}
+
+								<div className="flex justify-between items-start mt-2 mb-3">
+									<h3
+										className="font-semibold text-lg text-neutral-800 truncate"
+										title={report.city}
+									>
+										{report.city || "Ville Inconnue"}
+									</h3>
+									<div className="bg-primary/10 text-primary text-xs px-2.5 py-1 rounded-full font-medium">
+										{report.department.code}
+									</div>
+								</div>
+
+								<div className="space-y-1 mb-6 flex-grow">
+									<p className="text-sm text-neutral-600">
+										<span className="font-medium text-neutral-900">
+											Surface :
+										</span>{" "}
+										{report.totalAreaHectare?.toFixed(1) || 0} ha
+									</p>
+									<p className="text-sm text-neutral-600">
+										<span className="font-medium text-neutral-900">
+											Date de maj :
+										</span>{" "}
+										{new Date(report.updatedAt).toLocaleDateString("fr-FR")}
+									</p>
+								</div>
+
+								<div className="pt-4 border-t border-neutral-100 flex items-center justify-between text-sm font-medium text-primary group-hover:text-primary-dark transition-colors">
+									<span>Traiter la demande</span>
+									<ChevronRight className="h-4 w-4 transform group-hover:translate-x-1 transition-transform" />
+								</div>
+							</div>
+						))}
+					</div>
+				</div>
+			)}
+
+			{reports.length === 0 && pendingUsers.length === 0 && (
 				<div className="flex flex-col items-center justify-center p-12 bg-neutral-50 rounded-xl shadow-sm border border-neutral-100 mt-4">
 					<div className="h-16 w-16 bg-white rounded-full flex items-center justify-center mb-4 shadow-sm">
 						<FileWarning className="h-8 w-8 text-green-500" />
@@ -105,60 +258,6 @@ export function ActionRequiredTab() {
 					<p className="text-neutral-500 text-center max-w-sm mb-6">
 						Toutes les demandes ont été traitées.
 					</p>
-				</div>
-			) : (
-				<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-					{reports.map((report) => (
-						<div
-							key={report.id}
-							className="bg-white p-5 rounded-xl shadow-sm border border-neutral-200 hover:shadow-md hover:border-primary/30 transition-all cursor-pointer flex flex-col group relative overflow-hidden"
-							onClick={() => navigate({ to: `/clear-cuts/${report.id}` })}
-						>
-							{/* Indicating the type of action needed */}
-							{report.status === "to_validate" && (
-								<div className="absolute top-0 right-0 bg-blue-500 text-white text-[10px] px-2 py-1 rounded-bl-lg font-bold uppercase tracking-wider">
-									Nouvelle Zone
-								</div>
-							)}
-							{report.assignmentRequestedById && (
-								<div className="absolute top-0 right-0 bg-amber-500 text-white text-[10px] px-2 py-1 rounded-bl-lg font-bold uppercase tracking-wider">
-									Demande Attribution
-								</div>
-							)}
-
-							<div className="flex justify-between items-start mt-2 mb-3">
-								<h3
-									className="font-semibold text-lg text-neutral-800 truncate"
-									title={report.city}
-								>
-									{report.city || "Ville Inconnue"}
-								</h3>
-								<div className="bg-primary/10 text-primary text-xs px-2.5 py-1 rounded-full font-medium">
-									{report.department.code}
-								</div>
-							</div>
-
-							<div className="space-y-1 mb-6 flex-grow">
-								<p className="text-sm text-neutral-600">
-									<span className="font-medium text-neutral-900">
-										Surface :
-									</span>{" "}
-									{report.totalAreaHectare?.toFixed(1) || 0} ha
-								</p>
-								<p className="text-sm text-neutral-600">
-									<span className="font-medium text-neutral-900">
-										Date de maj :
-									</span>{" "}
-									{new Date(report.updatedAt).toLocaleDateString("fr-FR")}
-								</p>
-							</div>
-
-							<div className="pt-4 border-t border-neutral-100 flex items-center justify-between text-sm font-medium text-primary group-hover:text-primary-dark transition-colors">
-								<span>Traiter la demande</span>
-								<ChevronRight className="h-4 w-4 transform group-hover:translate-x-1 transition-transform" />
-							</div>
-						</div>
-					))}
 				</div>
 			)}
 		</div>

--- a/frontend/src/features/admin/components/reports-list/ReportsTrackingTab.tsx
+++ b/frontend/src/features/admin/components/reports-list/ReportsTrackingTab.tsx
@@ -1,11 +1,12 @@
 import { useNavigate } from "@tanstack/react-router"
-import { ChevronRight, Users, UserMinus, UserCheck } from "lucide-react"
+import { ChevronRight, RotateCcw, Users, UserMinus, UserCheck } from "lucide-react"
 import { useEffect, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
 	getAdminAllReportsThunk,
-	selectAdminAllReports
+	selectAdminAllReports,
+	updateReportStatusThunk
 } from "@/features/clear-cut/store/clear-cuts-slice"
 import { CLEAR_CUTTING_STATUS_TRANSLATIONS } from "@/features/clear-cut/store/status"
 import { TimeProgress } from "@/shared/components/TimeProgress"
@@ -21,6 +22,13 @@ export function ReportsTrackingTab() {
 	useEffect(() => {
 		dispatch(getAdminAllReportsThunk({ page: 0, size: 100 }))
 	}, [dispatch])
+
+	const handleResetToInProgress = (e: React.MouseEvent, reportId: string) => {
+		e.stopPropagation()
+		dispatch(updateReportStatusThunk({ id: reportId, status: "in_progress" })).then(() => {
+			dispatch(getAdminAllReportsThunk({ page: 0, size: 100 }))
+		})
+	}
 
 	if (reportsState.status === "idle" || reportsState.status === "loading") {
 		return (
@@ -134,9 +142,23 @@ export function ReportsTrackingTab() {
 									{report.totalAreaHectare?.toFixed(1) || 0} ha
 								</td>
 								<td className="px-6 py-4 text-right">
-									<Button variant="ghost" size="icon" className="group-hover:text-primary transition-colors">
-										<ChevronRight size={20} />
-									</Button>
+									<div className="flex items-center justify-end gap-1">
+										{(report.status === "validated" || report.status === "legal_validated" || report.status === "final_validated") && (
+											<Button
+												variant="outline"
+												size="sm"
+												className="text-xs text-orange-600 border-orange-200 hover:bg-orange-50 min-h-[36px] gap-1"
+												title="Remettre en traitement"
+												onClick={(e) => handleResetToInProgress(e, report.id)}
+											>
+												<RotateCcw size={13} />
+												<span className="hidden sm:inline">En traitement</span>
+											</Button>
+										)}
+										<Button variant="ghost" size="icon" className="group-hover:text-primary transition-colors">
+											<ChevronRight size={20} />
+										</Button>
+									</div>
 								</td>
 							</tr>
 						))}

--- a/frontend/src/features/clear-cut/components/form/ClearCutFullForm.tsx
+++ b/frontend/src/features/clear-cut/components/form/ClearCutFullForm.tsx
@@ -12,8 +12,11 @@ import {
 } from "@/features/clear-cut/store/clear-cuts"
 import {
 	persistClearCutCurrentForm,
+	requestAssignReportThunk,
+	selectAssignation,
 	selectSubmission,
-	submitClearCutFormThunk
+	submitClearCutFormThunk,
+	volunteerValidateThunk
 } from "@/features/clear-cut/store/clear-cuts-slice"
 import { useConnectedMe, useMe } from "@/features/user/store/me.slice"
 import { useToast } from "@/hooks/use-toast"
@@ -27,23 +30,46 @@ type Props = ClearCutFormVersions
 export function ClearCutFullForm({ current, original, latest }: Props) {
 	const dispatch = useAppDispatch()
 	const submission = useAppSelector(selectSubmission)
+	const assignation = useAppSelector(selectAssignation)
 	const loggedUser = useMe()
 	const user = useConnectedMe()
+
+	const isAssignedVolunteer = useMemo(() => {
+		if (!user || user.role !== "volunteer") return false
+		return (
+			current.report.userId === user.id ||
+			current.report.affectedUser?.login === user.login
+		)
+	}, [user, current.report.userId, current.report.affectedUser])
+
 	const isDisabled = useMemo(() => {
 		if (!user) return true
-
 		if (user.role === "volunteer") {
-			const isAffectedUser =
-				current.report.userId === user.id ||
-				(current.report.affectedUser?.login === user.login)
+			const lockedStatuses = ["waiting_for_validation", "validated", "legal_validated", "final_validated"]
+			if (lockedStatuses.includes(current.report.status)) return true
 			const isAssignmentRequester =
 				current.report.assignmentRequestedById === user.id
-
-			return !isAffectedUser && !isAssignmentRequester
+			return !isAssignedVolunteer && !isAssignmentRequester
 		}
-
 		return false
-	}, [user, current.report.userId, current.report.affectedUser, current.report.assignmentRequestedById])
+	}, [user, isAssignedVolunteer, current.report.assignmentRequestedById, current.report.status])
+
+	const canValidate =
+		isAssignedVolunteer && current.report.status === "in_progress"
+
+	const canRequestAssignment =
+		user?.role === "volunteer" &&
+		!current.report.userId &&
+		!current.report.assignmentRequestedById
+
+	const hasPendingRequest =
+		user?.role === "volunteer" &&
+		current.report.assignmentRequestedById === user.id
+
+	const handleRequestAssignment = () => {
+		dispatch(requestAssignReportThunk(current.report.id))
+	}
+
 	const form = useForm({
 		resolver: zodResolver(clearCutFormSchema),
 		values: current,
@@ -71,9 +97,13 @@ export function ClearCutFullForm({ current, original, latest }: Props) {
 		)
 	}
 
+	const handleValidate = () => {
+		dispatch(volunteerValidateThunk(current.report.id))
+	}
+
 	useEffect(() => {
 		if (submission.status === "success") {
-			toast({ id: "edited-form", title: "Formulaire modifié" })
+			toast({ id: "edited-form", title: "Formulaire sauvegardé" })
 		} else if (submission.status === "error") {
 			toast({
 				id: "form-edition-error",
@@ -81,6 +111,17 @@ export function ClearCutFullForm({ current, original, latest }: Props) {
 			})
 		}
 	}, [submission.status, toast])
+
+	useEffect(() => {
+		if (assignation.status === "success") {
+			toast({ id: "assignation-action", title: "Demande envoyée à l'administrateur" })
+		} else if (assignation.status === "error") {
+			toast({
+				id: "validation-error",
+				title: "Erreur lors de la demande de validation"
+			})
+		}
+	}, [assignation.status, toast])
 
 	return (
 		<>
@@ -98,16 +139,50 @@ export function ClearCutFullForm({ current, original, latest }: Props) {
 						<AccordionContent original={original} form={form} latest={latest} />
 					</Accordion>
 					{!!loggedUser && (
-						<Button
-							type="submit"
-							className="mx-auto my-1 text-xl font-bold cursor-pointer"
-							size="lg"
-							disabled={isDisabled || submission.status === "loading"}
-						>
-							{submission.status === "loading"
-								? "Envoi en cours..."
-								: "Valider"}
-						</Button>
+						<div className="flex flex-col gap-2 py-2">
+							{canRequestAssignment && (
+								<Button
+									type="button"
+									className="w-full cursor-pointer bg-green-600 hover:bg-green-700 text-white"
+									size="lg"
+									disabled={assignation.status === "loading"}
+									onClick={handleRequestAssignment}
+								>
+									{assignation.status === "loading"
+										? "Envoi en cours..."
+										: "Demander l'attribution"}
+								</Button>
+							)}
+							{hasPendingRequest && (
+								<p className="text-sm text-amber-600 font-medium text-center py-2">
+									⏳ Demande d'attribution en attente de validation
+								</p>
+							)}
+							<Button
+								type="submit"
+								variant="outline"
+								className="w-full cursor-pointer"
+								size="lg"
+								disabled={isDisabled || submission.status === "loading"}
+							>
+								{submission.status === "loading"
+									? "Enregistrement..."
+									: "Sauvegarder"}
+							</Button>
+							{canValidate && (
+								<Button
+									type="button"
+									className="w-full font-bold cursor-pointer bg-green-600 hover:bg-green-700 text-white"
+									size="lg"
+									disabled={assignation.status === "loading"}
+									onClick={handleValidate}
+								>
+									{assignation.status === "loading"
+										? "Envoi en cours..."
+										: "Valider la coupe"}
+								</Button>
+							)}
+						</div>
 					)}
 				</form>
 			</FormProvider>

--- a/frontend/src/features/clear-cut/components/map/ClearCutMapPopUp.tsx
+++ b/frontend/src/features/clear-cut/components/map/ClearCutMapPopUp.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@tanstack/react-router"
 import { useMemo } from "react"
 import { FormattedDate, FormattedNumber, useIntl } from "react-intl"
 import { Popup, useMap } from "react-leaflet"
@@ -5,7 +6,6 @@ import { Popup, useMap } from "react-leaflet"
 import { Button } from "@/components/ui/button"
 import { DotByStatus } from "@/features/clear-cut/components/DotByStatus"
 import { RuleBadge } from "@/features/clear-cut/components/RuleBadge"
-import { useNavigateToClearCut } from "@/features/clear-cut/hooks"
 import type { ClearCutReport } from "@/features/clear-cut/store/clear-cuts"
 import {
 	requestAssignReportThunk,
@@ -88,7 +88,6 @@ export function ClearCutMapPopUp({
 	const dispatch = useAppDispatch()
 	const user = useConnectedMe()
 	const filters = useAppSelector(selectFiltersRequest)
-	const navigateToDetail = useNavigateToClearCut(id)
 	const { toast } = useToast()
 	const map = useMap()
 
@@ -127,12 +126,13 @@ export function ClearCutMapPopUp({
 							type="button"
 							onClick={(e) => {
 								e.stopPropagation()
+								e.nativeEvent.stopImmediatePropagation()
 								dispatchAndRefresh(
 									unassignReportThunk(id),
 									"Impossible d'annuler l'attribution."
 								)
 							}}
-							className="w-full text-xs h-8 cursor-pointer"
+							className="w-full text-xs min-h-[44px] cursor-pointer"
 							variant="destructive"
 							size="sm"
 						>
@@ -171,12 +171,13 @@ export function ClearCutMapPopUp({
 					type="button"
 					onClick={(e) => {
 						e.stopPropagation()
+						e.nativeEvent.stopImmediatePropagation()
 						dispatchAndRefresh(
 							requestAssignReportThunk(id),
 							"Impossible de demander l'attribution."
 						)
 					}}
-					className="w-full text-xs h-8 bg-green-600 hover:bg-green-700 text-white cursor-pointer"
+					className="w-full text-xs min-h-[44px] bg-green-600 hover:bg-green-700 text-white cursor-pointer"
 					size="sm"
 				>
 					Demander l'attribution
@@ -257,17 +258,13 @@ export function ClearCutMapPopUp({
 
 			<div className="flex flex-col gap-2 mt-4 pt-3 border-t border-neutral-100">
 				{renderAssignmentSection()}
-				<Button
-					type="button"
-					onClick={(e) => {
-						e.stopPropagation()
-						navigateToDetail()
-					}}
-					className="w-full text-xs h-8 cursor-pointer"
-					variant="outline"
+				<Link
+					to="/clear-cuts/$clearCutId"
+					params={{ clearCutId: id }}
+					className="flex items-center justify-center w-full min-h-[44px] text-xs rounded-md border border-input bg-background px-3 py-2 font-medium hover:bg-accent hover:text-accent-foreground cursor-pointer"
 				>
 					Renseigner les informations
-				</Button>
+				</Link>
 			</div>
 		</Popup>
 	)

--- a/frontend/src/features/clear-cut/components/map/ClearCutPreview.tsx
+++ b/frontend/src/features/clear-cut/components/map/ClearCutPreview.tsx
@@ -10,7 +10,6 @@ import type {
 	ClearCutReport
 } from "@/features/clear-cut/store/clear-cuts"
 import { CLEAR_CUTTING_STATUS_COLORS } from "@/features/clear-cut/store/status"
-import { useBreakpoint } from "@/shared/hooks/breakpoint"
 
 type Props = { report: ClearCutReport; clearCut: ClearCut }
 
@@ -19,7 +18,6 @@ export function ClearCutPreview({ report, clearCut }: Props) {
 	const ref = useRef<L.FeatureGroup>(null)
 	const location = useLocation()
 	const navigateToDetail = useNavigateToClearCut(report.id)
-	const { breakpoint } = useBreakpoint()
 	useEffect(() => {
 		if (focusedClearCutId === report.id) {
 			if (ref.current && (ref.current as any)._map) {
@@ -61,12 +59,8 @@ export function ClearCutPreview({ report, clearCut }: Props) {
 				dblclick: () => {
 					navigateToDetail()
 				},
-				click: (event) => {
-					if (breakpoint !== "mobile") {
-						navigateToDetail()
-					} else {
-						event.target.openPopup()
-					}
+				click: () => {
+					navigateToDetail()
 				},
 				popupopen: () => {
 					setFocusedClearCutId(report.id)

--- a/frontend/src/features/clear-cut/store/clear-cuts-slice.ts
+++ b/frontend/src/features/clear-cut/store/clear-cuts-slice.ts
@@ -356,6 +356,30 @@ export const updateReportStatusThunk = createAppAsyncThunk<void, { id: string, s
 	}
 )
 
+export const volunteerValidateThunk = createAppAsyncThunk<void, string>(
+	"clear-cuts/volunteerValidate",
+	async (reportId, { extra: { api }, dispatch }) => {
+		await api().post(`api/v1/clear-cuts-reports/${reportId}/volunteer-validate`).json()
+		dispatch(getClearCutFormThunk({ id: reportId, hasBeenCreated: true }))
+	}
+)
+
+export const approveValidationThunk = createAppAsyncThunk<void, string>(
+	"clear-cuts/approveValidation",
+	async (reportId, { extra: { api }, dispatch }) => {
+		await api().post(`api/v1/clear-cuts-reports/${reportId}/approve-validation`).json()
+		dispatch(getClearCutFormThunk({ id: reportId }))
+	}
+)
+
+export const rejectValidationThunk = createAppAsyncThunk<void, string>(
+	"clear-cuts/rejectValidation",
+	async (reportId, { extra: { api }, dispatch }) => {
+		await api().post(`api/v1/clear-cuts-reports/${reportId}/reject-validation`).json()
+		dispatch(getClearCutFormThunk({ id: reportId }))
+	}
+)
+
 type State = {
 	clearCuts: RequestedContent<ClearCuts>
 	detail: RequestedContent<ClearCutFormVersions>
@@ -466,7 +490,22 @@ export const clearCutsSlice = createSlice({
 		addRequestedContentCases(
 			builder,
 			updateReportStatusThunk,
-			(state) => state.assignation // Reuse assignation loading state for simplicity
+			(state) => state.assignation
+		)
+		addRequestedContentCases(
+			builder,
+			volunteerValidateThunk,
+			(state) => state.assignation
+		)
+		addRequestedContentCases(
+			builder,
+			approveValidationThunk,
+			(state) => state.assignation
+		)
+		addRequestedContentCases(
+			builder,
+			rejectValidationThunk,
+			(state) => state.assignation
 		)
 		builder.addCase(getMeThunk.fulfilled, (_, { payload: { favorites } }) => {
 			formStorage.syncStorage(favorites, clearCutFormVersionsSchema)

--- a/frontend/src/features/clear-cut/store/clear-cuts.ts
+++ b/frontend/src/features/clear-cut/store/clear-cuts.ts
@@ -11,6 +11,7 @@ export const DISPLAY_PREVIEW_ZOOM_LEVEL = 13
 
 export const CLEAR_CUTTING_STATUSES = [
 	"to_validate",
+	"in_progress",
 	"waiting_for_validation",
 	"validated",
 	"legal_validated",

--- a/frontend/src/features/clear-cut/store/status.ts
+++ b/frontend/src/features/clear-cut/store/status.ts
@@ -1,7 +1,8 @@
 import type { ClearCutStatus } from "@/features/clear-cut/store/clear-cuts"
 
 export const CLEAR_CUTTING_STATUS_COLORS = {
-	to_validate: "blue-500",
+	to_validate: "red-500",
+	in_progress: "blue-500",
 	waiting_for_validation: "orange-400",
 	legal_validated: "orange-500",
 	validated: "green-500",
@@ -10,7 +11,8 @@ export const CLEAR_CUTTING_STATUS_COLORS = {
 } as const
 
 export const CLEAR_CUTTING_STATUS_BACKGROUND_COLORS = {
-	to_validate: "bg-blue-500",
+	to_validate: "bg-red-500",
+	in_progress: "bg-blue-500",
 	waiting_for_validation: "bg-orange-400",
 	legal_validated: "bg-orange-500",
 	validated: "bg-green-500",
@@ -22,9 +24,10 @@ export type StatusColor = (typeof CLEAR_CUTTING_STATUS_COLORS)[ClearCutStatus]
 
 export const CLEAR_CUTTING_STATUS_TRANSLATIONS: Record<ClearCutStatus, string> =
 	{
-		to_validate: "À vérifier",
-		waiting_for_validation: "En attente de validation terrain",
-		validated: "Validé",
+		to_validate: "À traiter",
+		in_progress: "En traitement",
+		waiting_for_validation: "En attente de validation",
+		validated: "Traitée",
 		legal_validated: "Validé avec poursuites",
 		final_validated: "Validé sans poursuites",
 		rejected: "Rejeté"

--- a/frontend/src/shared/form/components/FormS3ImageUpload.tsx
+++ b/frontend/src/shared/form/components/FormS3ImageUpload.tsx
@@ -1,10 +1,9 @@
-import { AlertCircle, ChevronLeft, ChevronRight, X, ZoomIn } from "lucide-react"
-import { type ChangeEvent, useEffect, useState } from "react"
+import { AlertCircle, Camera, ChevronLeft, ChevronRight, ImagePlus, X, ZoomIn } from "lucide-react"
+import { type ChangeEvent, useEffect, useRef, useState } from "react"
 import type { FieldValues } from "react-hook-form"
 
 import { Button } from "@/components/ui/button"
 import { Progress } from "@/components/ui/progress"
-import { Input } from "@/shared/components/input/Input"
 import { useImageUpload } from "@/shared/hooks/useImageUpload"
 import { useImageViewer } from "@/shared/hooks/useImageViewer"
 
@@ -39,163 +38,178 @@ function FormS3ImageField<T extends FieldValues>({
 	const { uploadImages, uploading, error, progress } = useImageUpload()
 	const { getViewableUrls, loading: viewerLoading } = useImageViewer()
 	const [uploadedImages, setUploadedImages] = useState<string[]>([])
-	const handleFileUploadWithField = async (
-		event: ChangeEvent<HTMLInputElement>
-	) => {
-		const files = event.target.files
-		if (!files || files.length === 0) return
 
+	const galleryInputRef = useRef<HTMLInputElement>(null)
+	const cameraInputRef = useRef<HTMLInputElement>(null)
+
+	const handleFiles = async (files: FileList | null) => {
+		if (!files || files.length === 0) return
 		try {
 			const uploaded = await uploadImages(files, reportId)
-			// Save S3 keys to form data
 			const s3Keys = uploaded.map((img) => img.key)
 			const newUploadedImages = [...uploadedImages, ...s3Keys]
 			setUploadedImages(newUploadedImages)
-
-			// Update form field immediately
 			field.onChange(newUploadedImages)
 		} catch (_e) {}
 	}
 
-	const removeImageWithField = (indexToRemove: number) => {
-		// Remove from both S3 keys and preview URLs
-		const newUploadedImages = uploadedImages.filter(
-			(_, index) => index !== indexToRemove
-		)
-		const newPreviewUrls = previewUrls.filter(
-			(_, index) => index !== indexToRemove
-		)
+	const handleGalleryChange = (e: ChangeEvent<HTMLInputElement>) =>
+		handleFiles(e.target.files)
+	const handleCameraChange = (e: ChangeEvent<HTMLInputElement>) =>
+		handleFiles(e.target.files)
 
+	const removeImageWithField = (indexToRemove: number) => {
+		const newUploadedImages = uploadedImages.filter((_, i) => i !== indexToRemove)
+		const newPreviewUrls = previewUrls.filter((_, i) => i !== indexToRemove)
 		setUploadedImages(newUploadedImages)
 		onPreviewUrlsChanged(newPreviewUrls)
-
-		// Update form field immediately
 		field.onChange(newUploadedImages)
 	}
-	// // Load existing images from S3 keys when form value changes (on mount or external change)
+
 	useEffect(() => {
 		if (field.value && Array.isArray(field.value) && field.value.length > 0) {
-			// Check if these are S3 keys (not blob URLs)
 			const s3Keys = field.value.filter(
 				(item: string) => typeof item === "string" && !item.startsWith("blob:")
 			)
-
 			if (s3Keys.length > 0) {
 				getViewableUrls(s3Keys).then((viewableUrls) => {
 					setUploadedImages(s3Keys)
 					onPreviewUrlsChanged(viewableUrls)
 				})
 			}
-		} else if (!field.value || field.value.length === 0) {
-			// setUploadedImages(EMPTY_ARRAY);
-			// onPreviewUrlsChanged(EMPTY_ARRAY);
 		}
 	}, [field.value, getViewableUrls, onPreviewUrlsChanged])
+
+	const isDisabled = field.disabled || uploading
 
 	return (
 		<FormItem>
 			{label && <FormLabel className="font-bold">{label}</FormLabel>}
 			<FormControl>
-				<Input
-					type="file"
-					accept="image/*"
-					multiple
-					disabled={field.disabled || uploading}
-					onChange={handleFileUploadWithField}
-					placeholder={placeholder}
-					className="max-w-fit"
-				/>
-			</FormControl>
-			{/* Additional UI for the upload component */}
-			<div className="space-y-4">
-				{/* Upload Progress and Status */}
-				{(uploading || viewerLoading) && (
-					<div className="flex items-center gap-2 text-sm text-gray-600">
-						{/* Circular Spinner */}
-						<svg
-							className="h-4 w-4 animate-spin text-gray-500"
-							viewBox="0 0 24 24"
-							fill="none"
-							xmlns="http://www.w3.org/2000/svg"
-							aria-hidden="true"
+				<div className="flex flex-col gap-2">
+					{/* Hidden file inputs */}
+					<input
+						ref={galleryInputRef}
+						type="file"
+						accept="image/*"
+						multiple
+						className="hidden"
+						disabled={isDisabled}
+						onChange={handleGalleryChange}
+						aria-label={`Sélectionner des photos — ${label ?? placeholder}`}
+					/>
+					<input
+						ref={cameraInputRef}
+						type="file"
+						accept="image/*"
+						capture="environment"
+						className="hidden"
+						disabled={isDisabled}
+						onChange={handleCameraChange}
+						aria-label={`Prendre une photo — ${label ?? placeholder}`}
+					/>
+
+					{/* Action buttons — touch-friendly, full width on mobile */}
+					<div className="flex gap-2">
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							className="flex-1 min-h-[44px] gap-2 text-sm"
+							disabled={isDisabled}
+							onClick={() => galleryInputRef.current?.click()}
 						>
-							<circle
-								className="opacity-25"
-								cx="12"
-								cy="12"
-								r="10"
-								stroke="currentColor"
-								strokeWidth="4"
-							/>
-							<path
-								className="opacity-75"
-								fill="currentColor"
-								d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
-							/>
-						</svg>
-						{uploading ? "Uploading..." : "Loading images..."}
+							<ImagePlus className="h-4 w-4 shrink-0" />
+							<span>{uploading ? "Envoi…" : "Galerie"}</span>
+						</Button>
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							className="flex-1 min-h-[44px] gap-2 text-sm"
+							disabled={isDisabled}
+							onClick={() => cameraInputRef.current?.click()}
+						>
+							<Camera className="h-4 w-4 shrink-0" />
+							<span>Appareil photo</span>
+						</Button>
 					</div>
-				)}
+				</div>
+			</FormControl>
 
-				{/* Progress Bar */}
-				{uploading && <Progress value={progress} className="w-full" />}
+			{/* Progress and status */}
+			{(uploading || viewerLoading) && (
+				<div className="flex items-center gap-2 text-sm text-gray-600 mt-1">
+					<svg
+						className="h-4 w-4 animate-spin text-gray-500 shrink-0"
+						viewBox="0 0 24 24"
+						fill="none"
+						aria-hidden="true"
+					>
+						<circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+						<path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+					</svg>
+					{uploading ? "Envoi en cours…" : "Chargement des photos…"}
+				</div>
+			)}
 
-				{/* Error Message */}
-				{error && (
-					<div className="flex items-center gap-2 text-sm text-red-600">
-						<AlertCircle className="h-4 w-4" />
-						{error}
-					</div>
-				)}
+			{uploading && <Progress value={progress} className="w-full" />}
 
-				{/* Uploaded Images Preview */}
-				{previewUrls.length > 0 && (
-					<div className="space-y-2">
-						<p className="text-sm font-medium text-gray-700">
-							Images uploaded ({previewUrls.length})
-						</p>
-						<div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2">
-							{previewUrls.map((imageUrl, index) => (
-								<div key={imageUrl} className="relative group">
-									<button
-										type="button"
-										className="relative cursor-pointer w-full h-full bg-transparent border-none p-0"
-										onClick={() => onSelectedImageIndexChanged(index)}
-										aria-label={`View image ${index + 1}`}
-									>
-										<img
-											src={imageUrl}
-											alt={`Upload ${index + 1}`}
-											className="w-full h-24 object-cover rounded border hover:opacity-75 transition-opacity"
-											onError={(e) => {
-												// Fallback for broken images
-												e.currentTarget.src =
-													"data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'><rect width='100' height='100' fill='%23f0f0f0'/><text x='50' y='50' font-family='Arial' font-size='12' fill='%23666' text-anchor='middle' dy='0.3em'>Image</text></svg>"
-											}}
-										/>
-										<div className="absolute inset-0 flex items-center justify-center opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity bg-opacity-30 rounded">
-											<ZoomIn className="h-6 w-6 text-white" />
-										</div>
-									</button>
-									<Button
-										type="button"
-										variant="destructive"
-										size="sm"
-										className="absolute -top-2 -right-2 h-6 w-6 rounded-full p-0 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity"
-										onClick={(e) => {
-											e.stopPropagation()
-											removeImageWithField(index)
+			{error && (
+				<div className="flex items-start gap-2 text-sm text-red-600 mt-1">
+					<AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+					<span>{error}</span>
+				</div>
+			)}
+
+			{/* Image previews */}
+			{previewUrls.length > 0 && (
+				<div className="space-y-2 mt-2">
+					<p className="text-sm font-medium text-gray-700">
+						{previewUrls.length} photo{previewUrls.length > 1 ? "s" : ""}
+					</p>
+					<div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2">
+						{previewUrls.map((imageUrl, index) => (
+							<div key={imageUrl} className="relative group">
+								<button
+									type="button"
+									className="relative cursor-pointer w-full bg-transparent border-none p-0"
+									onClick={() => onSelectedImageIndexChanged(index)}
+									aria-label={`Voir la photo ${index + 1}`}
+								>
+									<img
+										src={imageUrl}
+										alt={`Photo ${index + 1}`}
+										className="w-full h-24 object-cover rounded border hover:opacity-75 transition-opacity"
+										onError={(e) => {
+											e.currentTarget.src =
+												"data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'><rect width='100' height='100' fill='%23f0f0f0'/><text x='50' y='50' font-family='Arial' font-size='12' fill='%23666' text-anchor='middle' dy='0.3em'>Photo</text></svg>"
 										}}
-										disabled={uploading}
-									>
-										<X className="h-3 w-3" />
-									</Button>
-								</div>
-							))}
-						</div>
+									/>
+									<div className="absolute inset-0 flex items-center justify-center opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity bg-opacity-30 rounded">
+										<ZoomIn className="h-6 w-6 text-white drop-shadow" />
+									</div>
+								</button>
+								<Button
+									type="button"
+									variant="destructive"
+									size="sm"
+									className="absolute -top-2 -right-2 h-7 w-7 rounded-full p-0 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity"
+									onClick={(e) => {
+										e.stopPropagation()
+										removeImageWithField(index)
+									}}
+									disabled={uploading}
+									aria-label={`Supprimer la photo ${index + 1}`}
+								>
+									<X className="h-3 w-3" />
+								</Button>
+							</div>
+						))}
 					</div>
-				)}
-			</div>
+				</div>
+			)}
+
 			<FormMessage />
 		</FormItem>
 	)
@@ -207,28 +221,22 @@ export function FormS3ImageUpload<T extends FieldValues = FieldValues>({
 	...props
 }: Forms3ImageUploadProps<T>) {
 	const [previewUrls, setPreviewUrls] = useState<string[]>([])
-	const [selectedImageIndex, setSelectedImageIndex] = useState<number>()
+	const [selectedImageIndex, setSelectedImageIndex] = useState<number | undefined>()
 
-	// Handle keyboard navigation for modal
 	useEffect(() => {
 		const handleKeyDown = (event: KeyboardEvent) => {
 			if (selectedImageIndex === undefined) return
-
 			switch (event.key) {
 				case "ArrowLeft":
 					event.preventDefault()
 					setSelectedImageIndex(
-						selectedImageIndex > 0
-							? selectedImageIndex - 1
-							: previewUrls.length - 1
+						selectedImageIndex > 0 ? selectedImageIndex - 1 : previewUrls.length - 1
 					)
 					break
 				case "ArrowRight":
 					event.preventDefault()
 					setSelectedImageIndex(
-						selectedImageIndex < previewUrls.length - 1
-							? selectedImageIndex + 1
-							: 0
+						selectedImageIndex < previewUrls.length - 1 ? selectedImageIndex + 1 : 0
 					)
 					break
 				case "Escape":
@@ -237,14 +245,10 @@ export function FormS3ImageUpload<T extends FieldValues = FieldValues>({
 					break
 			}
 		}
-
-		if (selectedImageIndex !== null) {
+		if (selectedImageIndex !== undefined) {
 			document.addEventListener("keydown", handleKeyDown)
 		}
-
-		return () => {
-			document.removeEventListener("keydown", handleKeyDown)
-		}
+		return () => document.removeEventListener("keydown", handleKeyDown)
 	}, [selectedImageIndex, previewUrls.length])
 
 	return (
@@ -258,42 +262,35 @@ export function FormS3ImageUpload<T extends FieldValues = FieldValues>({
 				onSelectedImageIndexChanged={setSelectedImageIndex}
 			/>
 
-			{/* Image Preview Modal */}
+			{/* Lightbox modal */}
 			{selectedImageIndex !== undefined && (
 				<button
 					type="button"
-					className="fixed inset-0 flex items-center justify-center z-50 bg-transparent border-none p-0"
-					style={{ backgroundColor: "rgba(0, 0, 0, 0.5)" }}
+					className="fixed inset-0 flex items-center justify-center z-50 border-none p-0"
+					style={{ backgroundColor: "rgba(0,0,0,0.85)" }}
 					onClick={() => setSelectedImageIndex(undefined)}
-					aria-label="Close modal"
+					aria-label="Fermer"
 				>
-					<div className="relative max-w-4xl max-h-full p-4">
+					<div className="relative w-full max-w-4xl max-h-screen p-4">
 						<img
 							src={previewUrls[selectedImageIndex]}
-							alt={`Preview ${selectedImageIndex + 1}`}
-							className="max-w-full max-h-full object-contain rounded shadow-lg"
+							alt={`Photo ${selectedImageIndex + 1}`}
+							className="max-w-full max-h-[80vh] object-contain rounded shadow-lg mx-auto block"
 							onClick={(e) => e.stopPropagation()}
-							onKeyDown={(e) => {
-								if (e.key === "Enter" || e.key === " ") {
-									e.preventDefault()
-									e.stopPropagation()
-								}
-							}}
+							onKeyDown={(e) => e.stopPropagation()}
 						/>
-						{/* Navigation arrows if multiple images */}
+
 						{previewUrls.length > 1 && (
 							<>
 								<Button
 									type="button"
 									variant="outline"
 									size="lg"
-									className="absolute left-4 top-1/2 transform -translate-y-1/2 h-12 w-12 rounded-full p-0 bg-white/90 hover:bg-white border-gray-300 shadow-lg backdrop-blur-sm"
+									className="absolute left-2 top-1/2 -translate-y-1/2 h-12 w-12 rounded-full p-0 bg-white/90"
 									onClick={(e) => {
 										e.stopPropagation()
 										setSelectedImageIndex(
-											selectedImageIndex > 0
-												? selectedImageIndex - 1
-												: previewUrls.length - 1
+											selectedImageIndex > 0 ? selectedImageIndex - 1 : previewUrls.length - 1
 										)
 									}}
 								>
@@ -303,13 +300,11 @@ export function FormS3ImageUpload<T extends FieldValues = FieldValues>({
 									type="button"
 									variant="outline"
 									size="lg"
-									className="absolute right-4 top-1/2 transform -translate-y-1/2 h-12 w-12 rounded-full p-0 bg-white/90 hover:bg-white border-gray-300 shadow-lg backdrop-blur-sm"
+									className="absolute right-2 top-1/2 -translate-y-1/2 h-12 w-12 rounded-full p-0 bg-white/90"
 									onClick={(e) => {
 										e.stopPropagation()
 										setSelectedImageIndex(
-											selectedImageIndex < previewUrls.length - 1
-												? selectedImageIndex + 1
-												: 0
+											selectedImageIndex < previewUrls.length - 1 ? selectedImageIndex + 1 : 0
 										)
 									}}
 								>
@@ -317,6 +312,10 @@ export function FormS3ImageUpload<T extends FieldValues = FieldValues>({
 								</Button>
 							</>
 						)}
+
+						<p className="text-white text-center text-sm mt-2 opacity-70">
+							{selectedImageIndex + 1} / {previewUrls.length}
+						</p>
 					</div>
 				</button>
 			)}

--- a/frontend/src/shared/hooks/useImageUpload.ts
+++ b/frontend/src/shared/hooks/useImageUpload.ts
@@ -31,6 +31,22 @@ export interface UseImageUploadResult {
 	progress: number
 }
 
+const EXTENSION_TO_MIME: Record<string, string> = {
+	jpg: "image/jpeg",
+	jpeg: "image/jpeg",
+	png: "image/png",
+	gif: "image/gif",
+	webp: "image/webp",
+	heic: "image/jpeg",
+	heif: "image/jpeg"
+}
+
+function inferMimeType(file: File): string {
+	if (file.type && file.type.startsWith("image/")) return file.type
+	const ext = file.name.split(".").pop()?.toLowerCase() ?? ""
+	return EXTENSION_TO_MIME[ext] ?? "image/jpeg"
+}
+
 export function useImageUpload(): UseImageUploadResult {
 	const [uploading, setUploading] = useState(false)
 	const [error, setError] = useState<string | null>(null)
@@ -50,55 +66,43 @@ export function useImageUpload(): UseImageUploadResult {
 
 			for (let i = 0; i < totalFiles; i++) {
 				const file = files[i]
+				const contentType = inferMimeType(file)
 
-				// Validate file type
-				if (!file.type.startsWith("image/")) {
-					throw new Error(`File ${file.name} is not an image`)
+				if (!contentType.startsWith("image/")) {
+					throw new Error(`Le fichier "${file.name}" n'est pas une image.`)
 				}
 
-				// Validate file size (10MB limit)
 				const maxSize = 10 * 1024 * 1024
 				if (file.size > maxSize) {
 					throw new Error(
-						`File ${file.name} is too large (${(file.size / 1024 / 1024).toFixed(1)}MB). Maximum size is 10MB`
+						`Le fichier "${file.name}" est trop volumineux (${(file.size / 1024 / 1024).toFixed(1)} Mo). Taille maximale : 10 Mo.`
 					)
 				}
 
-				// Get pre-signed URL
+				const token = getStoredToken()
+				if (!token) {
+					throw new Error("Vous devez être connecté pour envoyer des photos.")
+				}
+
+				const authenticatedApi = api.extend({
+					headers: { Authorization: `Bearer ${token.accessToken}` }
+				})
+
 				const uploadRequest: ImageUploadRequest = {
 					filename: file.name,
-					content_type: file.type,
+					content_type: contentType,
 					file_size: file.size,
 					report_id: reportId
 				}
 
-				// Get authenticated API instance
-				const token = getStoredToken()
-				if (!token) {
-					throw new Error("Authentication required for image upload")
-				}
-
-				const authenticatedApi = api.extend({
-					headers: {
-						Authorization: `Bearer ${token.accessToken}`
-					}
-				})
-
 				const response = await authenticatedApi
-					.post("api/v1/images/upload-url", {
-						json: uploadRequest
-					})
+					.post("api/v1/images/upload-url", { json: uploadRequest })
 					.json<ImageUploadResponse>()
 
-				// Upload file directly to S3 using pre-signed POST
 				const formData = new FormData()
-
-				// Add all the fields from the pre-signed POST
 				for (const [key, value] of Object.entries(response.fields)) {
 					formData.append(key, value)
 				}
-
-				// Add the file last
 				formData.append("file", file)
 
 				const uploadResponse = await fetch(response.uploadUrl, {
@@ -108,7 +112,7 @@ export function useImageUpload(): UseImageUploadResult {
 
 				if (!uploadResponse.ok) {
 					throw new Error(
-						`Failed to upload ${file.name}: ${uploadResponse.statusText}`
+						`Échec de l'envoi de "${file.name}" (${uploadResponse.status} ${uploadResponse.statusText}).`
 					)
 				}
 
@@ -118,13 +122,13 @@ export function useImageUpload(): UseImageUploadResult {
 					filename: file.name
 				})
 
-				// Update progress
 				setProgress(((i + 1) / totalFiles) * 100)
 			}
 
 			return uploadedImages
 		} catch (err) {
-			const errorMessage = err instanceof Error ? err.message : "Upload failed"
+			const errorMessage =
+				err instanceof Error ? err.message : "Erreur lors de l'envoi de la photo."
 			setError(errorMessage)
 			throw err
 		} finally {
@@ -132,10 +136,5 @@ export function useImageUpload(): UseImageUploadResult {
 		}
 	}
 
-	return {
-		uploadImages,
-		uploading,
-		error,
-		progress
-	}
+	return { uploadImages, uploading, error, progress }
 }

--- a/frontend/src/shared/hooks/useImageViewer.ts
+++ b/frontend/src/shared/hooks/useImageViewer.ts
@@ -40,7 +40,7 @@ export function useImageViewer(): UseImageViewerResult {
 				s3Keys.map(async (s3Key) => {
 					try {
 						const response = await authenticatedApi
-							.get(`api/v1/images/view/${encodeURIComponent(s3Key)}`)
+							.get(`api/v1/images/view/${s3Key.split("/").map(encodeURIComponent).join("/")}`)
 							.json<ImageViewResponse>()
 						return response.viewUrl
 					} catch (_e) {

--- a/frontend/src/test/features/clear-cut/form-tracking.browser.test.tsx
+++ b/frontend/src/test/features/clear-cut/form-tracking.browser.test.tsx
@@ -11,7 +11,8 @@ import { renderApp } from "@/test/renderApp"
 
 const reportMock = mockClearCutReportResponse({
 	id: "ABC",
-	affectedUser: volunteerMock
+	affectedUser: volunteerMock,
+	status: "in_progress"
 })
 const formMock = mockClearCutFormsResponse({
 	reportId: reportMock.response.id

--- a/frontend/src/test/features/clear-cut/form.browser.test.tsx
+++ b/frontend/src/test/features/clear-cut/form.browser.test.tsx
@@ -196,7 +196,7 @@ const defaultSetupServerBeforeEach = (setup: ReturnType<typeof setupTest>) => {
 		worker.use(setup.reportMock.handler, setup.formMock.handler)
 	})
 }
-const setupVolunteerAssigned = setupTest({ affectedUser: volunteerMock })
+const setupVolunteerAssigned = setupTest({ affectedUser: volunteerMock, status: "in_progress" })
 describe.each(setupVolunteerAssigned.sections)(
 	"$section.name section form when there is volunteer assigned",
 	({ section, items }) => {

--- a/frontend/src/test/page-object/form-input.ts
+++ b/frontend/src/test/page-object/form-input.ts
@@ -64,6 +64,7 @@ export function formField<Form extends FieldValues, Value = unknown>({
 		case "textArea":
 			return fieldWithTextContentValue<Form>(item, user)
 		case "inputFile":
+			return inputFileField<Form>(item, user)
 		case "inputText":
 			return fieldWithValue<Form>(item, user)
 		case "switch":
@@ -220,6 +221,37 @@ function changeTrackingLabel(label: string, user: UserEvent) {
 			)
 			await user.click(button)
 		}
+	}
+}
+
+function inputFileField<Form extends FieldValues>(
+	item: InputFileItem<Form>,
+	user: UserEvent
+): FieldInput<string | null, HTMLButtonElement> {
+	const label = item.label ?? item.name
+	const findFormItem = async () => {
+		const labelEl = await screen.findByText(label, { selector: "label" })
+		return labelEl.parentElement as HTMLElement
+	}
+	const findElement = async () => {
+		const formItem = await findFormItem()
+		return within(formItem).findByRole("button", {
+			name: /Galerie/
+		}) as Promise<HTMLButtonElement>
+	}
+	return {
+		...changeTrackingLabel(label, user),
+		findElement,
+		findValue: async () => null,
+		isDisabled: async () => {
+			const btn = await findElement()
+			return btn.hasAttribute("disabled")
+		},
+		expectDisabledState: async (state) => {
+			const btn = await findElement()
+			expect(btn)[state === true ? "to" : "not"].toBeDisabled()
+		},
+		setValue: async () => {}
 	}
 }
 


### PR DESCRIPTION
Workflow de validation :
- Le benevole sauvegarde le formulaire autant de fois que necessaire
- Bouton "Valider la coupe" envoie le formulaire en waiting_for_validation
- Le formulaire est verrouille apres validation (lecture seule)
- L'admin valide (validated) ou remet en traitement (in_progress)
- Correction : la mise a jour du statut par l'admin ne reinitialise plus l'attribution benevole

Nouveau statut in_progress :
- Ajout de in_progress dans les statuts (couleur orange)
- L'admin peut remettre une coupe en traitement depuis l'onglet Coupes rases

Popup carte mobile :
- Le clic sur un polygone navigue directement vers la fiche (mobile et desktop)
- Demander l'attribution deplace dans la fiche formulaire
- Renseigner les informations remplace par un composant Link (TanStack Router)
- Boutons avec taille tactile minimale 44px

Actions requises (admin) :
- Boutons Approuver et Rejeter la validation benevole
- Email envoye au benevole en cas de rejet

Upload photos :
- Fallback MIME type pour compatibilite navigateurs mobiles
- Galerie et bouton appareil photo separes

### Description
Nocodb : _insérer le lien vers la tâche Nocodb correspondante_

_Merci de fournir une description détaillée de la tâche._

### Comment tester ?
_Merci d'indiquer comment tester les modifications apportées._

### Pour faciliter la validation de ma PR
- [ ] Les pre-commit passent
- [ ] Les test unitaires passent
- [ ] Le code modifié fonctionne en local/dev
- [ ] J'ai demandé une peer-review à un autre bénévole du projet
- [ ] La PR est bien formatée et respecte les conventions de style
- [ ] J'ai documenté les modifications apportées (dans le README.md, code ou dans un fichier spécifique si nécessaire)

### Auteur(s)
- [ ] Nom Prénom (GitHub ID)

### Peer Reviewer(s)
- [ ] Nom Prénom (GitHub ID)
