### PR TITLE
feat(coupe): éditer les infos initiales et le périmètre d'une coupe (#240)

### DIFF
--- a/backend/alembic/versions/a1b2c3d4e5f6_add_manual_edit_fields.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_manual_edit_fields.py
@@ -1,0 +1,76 @@
+"""Add manual edition tracking to clear cuts and reported_at to reports
+
+Allows admins and assigned volunteers to correct the initial information and
+perimeter of a clear cut. Manually edited cuts are flagged so the data pipeline
+does not overwrite them unless overriding is explicitly re-enabled.
+
+Revision ID: a1b2c3d4e5f6
+Revises: 548e40e6ac01
+Create Date: 2026-06-24 17:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | None = "548e40e6ac01"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "clear_cuts",
+        sa.Column(
+            "is_manually_edited",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "clear_cuts",
+        sa.Column("manually_edited_at", sa.DateTime(), nullable=True),
+    )
+    op.add_column(
+        "clear_cuts",
+        sa.Column("manually_edited_by_id", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "clear_cuts",
+        sa.Column(
+            "allow_pipeline_override",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+    )
+    op.create_foreign_key(
+        "fk_clear_cuts_manually_edited_by_id_users",
+        "clear_cuts",
+        "users",
+        ["manually_edited_by_id"],
+        ["id"],
+    )
+    op.add_column(
+        "clear_cuts_reports",
+        sa.Column("reported_at", sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("clear_cuts_reports", "reported_at")
+    op.drop_constraint(
+        "fk_clear_cuts_manually_edited_by_id_users",
+        "clear_cuts",
+        type_="foreignkey",
+    )
+    op.drop_column("clear_cuts", "allow_pipeline_override")
+    op.drop_column("clear_cuts", "manually_edited_by_id")
+    op.drop_column("clear_cuts", "manually_edited_at")
+    op.drop_column("clear_cuts", "is_manually_edited")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -282,9 +282,7 @@ class ClearCut(Base):
     is_manually_edited: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default=text("false"), default=False
     )
-    manually_edited_at: Mapped[datetime | None] = mapped_column(
-        DateTime, nullable=True
-    )
+    manually_edited_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     manually_edited_by_id: Mapped[int | None] = mapped_column(
         ForeignKey("users.id"), nullable=True
     )

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -276,6 +276,22 @@ class ClearCut(Base):
         ),
         nullable=True,
     )
+    # Manual edition tracking: when a clear cut's perimeter or dates are corrected
+    # by hand, we flag it so (a) the UI can signal it and (b) the data pipeline
+    # leaves it untouched on its next run — unless an admin re-enables overriding.
+    is_manually_edited: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("false"), default=False
+    )
+    manually_edited_at: Mapped[datetime | None] = mapped_column(
+        DateTime, nullable=True
+    )
+    manually_edited_by_id: Mapped[int | None] = mapped_column(
+        ForeignKey("users.id"), nullable=True
+    )
+    # When False (default once edited), the pipeline must not overwrite this cut.
+    allow_pipeline_override: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("false"), default=False
+    )
     report_id: Mapped[int] = mapped_column(
         ForeignKey("clear_cuts_reports.id"), index=True, nullable=False
     )
@@ -316,6 +332,8 @@ class ClearCutReport(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.now, onupdate=datetime.now, nullable=False
     )
+    # Editable "date de signalement". Falls back to created_at when null.
+    reported_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     clear_cuts: Mapped[list["ClearCut"]] = relationship(
         back_populates="report", cascade="all, delete"
     )

--- a/backend/app/routes/clear_cuts.py
+++ b/backend/app/routes/clear_cuts.py
@@ -1,10 +1,11 @@
 from logging import getLogger
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from app.deps import db_session
-from app.schemas.clear_cut import ClearCutResponseSchema
+from app.models import User
+from app.schemas.clear_cut import ClearCutPatchSchema, ClearCutResponseSchema
 from app.schemas.ecological_zoning import (
     ClearCutEcologicalZoningResponseSchema,
 )
@@ -13,7 +14,9 @@ from app.services.clear_cut import (
     find_clear_cuts,
     find_ecological_zonings_by_clear_cut,
     get_clearcut_by_id,
+    update_clear_cut_geometry,
 )
+from app.services.user_auth import get_current_user
 
 logger = getLogger(__name__)
 
@@ -48,6 +51,22 @@ def get_clear_cut(
 ) -> ClearCutResponseSchema:
     logger.info(db)
     return get_clearcut_by_id(id=clear_cut_id, db=db)
+
+
+@router.patch(
+    "/{clear_cut_id}",
+    response_model=ClearCutResponseSchema,
+    response_model_exclude_none=True,
+)
+def patch_clear_cut(
+    clear_cut_id: int,
+    item: ClearCutPatchSchema,
+    db: Session = db_session,
+    user: User = Depends(get_current_user),
+) -> ClearCutResponseSchema:
+    """Manually correct a clear cut's perimeter and/or observation dates."""
+    logger.info(db)
+    return update_clear_cut_geometry(db, clear_cut_id, user, item)
 
 
 @router.get(

--- a/backend/app/routes/clear_cuts_reports.py
+++ b/backend/app/routes/clear_cuts_reports.py
@@ -27,6 +27,7 @@ from app.services.clear_cut_report import (
     create_clear_cut_report,
     find_clearcuts_reports,
     get_report_response_by_id,
+    set_report_pipeline_override,
     sync_clear_cuts_reports,
     update_clear_cut_report,
     volunteer_create_clear_cut_report,
@@ -144,6 +145,25 @@ def update_existing_clear_cut_report(
 ) -> None:
     logger.info(db)
     update_clear_cut_report(report_id, db, user, item)
+
+
+class PipelineOverrideRequestSchema(BaseSchema):
+    allow: bool
+
+
+@router.post(
+    "/{report_id}/pipeline-override",
+    status_code=status.HTTP_200_OK,
+)
+def set_pipeline_override(
+    report_id: int,
+    params: PipelineOverrideRequestSchema,
+    user: User = Depends(get_current_user),
+    db: Session = db_session,
+):
+    """Toggle whether the pipeline may overwrite this report's manually edited cuts."""
+    set_report_pipeline_override(report_id, db, user, params.allow)
+    return {"allow_pipeline_override": params.allow}
 
 
 @router.get(

--- a/backend/app/schemas/clear_cut.py
+++ b/backend/app/schemas/clear_cut.py
@@ -82,6 +82,41 @@ class ClearCutCreateSchema(ClearCutBaseSchema):
     ecological_zonings: list[EcologicalZoningSchema] = Field(default=[])
 
 
+class ClearCutPatchSchema(BaseSchema):
+    """Partial update of a clear cut's perimeter and observation dates.
+
+    Only the provided fields are updated. Setting the perimeter triggers a
+    server-side recomputation of area and centroid.
+    """
+
+    boundary: MultiPolygon | None = Field(
+        default=None,
+        json_schema_extra={
+            "example": {
+                "type": "MultiPolygon",
+                "coordinates": [
+                    [
+                        [
+                            [2.3522, 48.8566],
+                            [2.3622, 48.8566],
+                            [2.3622, 48.8666],
+                            [2.3522, 48.8566],
+                        ]
+                    ]
+                ],
+            }
+        },
+    )
+    observation_start_date: datetime | None = Field(
+        default=None,
+        json_schema_extra={"example": "2023-01-01T00:00:00Z"},
+    )
+    observation_end_date: datetime | None = Field(
+        default=None,
+        json_schema_extra={"example": "2023-06-01T00:00:00Z"},
+    )
+
+
 class ClearCutResponseSchema(ClearCutBaseSchema):
     id: str = Field(
         json_schema_extra={
@@ -103,6 +138,9 @@ class ClearCutResponseSchema(ClearCutBaseSchema):
             "example": "2023-01-01T00:00:00Z",
         }
     )
+    is_manually_edited: bool = Field(default=False)
+    manually_edited_at: datetime | None = Field(default=None)
+    allow_pipeline_override: bool = Field(default=False)
 
 
 def clear_cut_to_clear_cut_response_schema(
@@ -123,4 +161,7 @@ def clear_cut_to_clear_cut_response_schema(
         bdf_mixed_area_hectare=clear_cut.bdf_mixed_area_hectare,
         bdf_poplar_area_hectare=clear_cut.bdf_poplar_area_hectare,
         ecological_zoning_area_hectare=clear_cut.ecological_zoning_area_hectare,
+        is_manually_edited=clear_cut.is_manually_edited,
+        manually_edited_at=clear_cut.manually_edited_at,
+        allow_pipeline_override=clear_cut.allow_pipeline_override,
     )

--- a/backend/app/schemas/clear_cut_map.py
+++ b/backend/app/schemas/clear_cut_map.py
@@ -82,6 +82,16 @@ class ClearCutReportPreviewSchema(BaseSchema):
         json_schema_extra={"example": "1"},
         default=None,
     )
+    reported_at: datetime.date | None = Field(
+        json_schema_extra={"example": "2023-10-01"},
+        default=None,
+    )
+    is_manually_edited: bool = Field(default=False)
+    manually_edited_at: datetime.date | None = Field(
+        json_schema_extra={"example": "2023-10-01"},
+        default=None,
+    )
+    allow_pipeline_override: bool = Field(default=False)
 
 
 def sum_area(clear_cuts: list[ClearCut], area_attr: str) -> float:
@@ -143,6 +153,25 @@ def report_to_report_preview_schema(
         first_cut_date=min(
             clear_cut.observation_start_date for clear_cut in report.clear_cuts
         ).date(),
+        reported_at=report.reported_at.date() if report.reported_at else None,
+        is_manually_edited=any(
+            clear_cut.is_manually_edited for clear_cut in report.clear_cuts
+        ),
+        manually_edited_at=(
+            max(
+                clear_cut.manually_edited_at
+                for clear_cut in report.clear_cuts
+                if clear_cut.manually_edited_at is not None
+            ).date()
+            if any(
+                clear_cut.manually_edited_at is not None
+                for clear_cut in report.clear_cuts
+            )
+            else None
+        ),
+        allow_pipeline_override=any(
+            clear_cut.allow_pipeline_override for clear_cut in report.clear_cuts
+        ),
     )
 
 

--- a/backend/app/schemas/clear_cut_report.py
+++ b/backend/app/schemas/clear_cut_report.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from logging import getLogger
 
 from pydantic import EmailStr, Field, field_validator
@@ -32,6 +33,8 @@ class CreateClearCutsReportCreateRequestSchema(BaseSchema):
 class ClearCutReportPutRequestSchema(BaseSchema):
     status: str | None = None
     user_id: int | None = None
+    reported_at: datetime | None = None
+    city_zip_code: str | None = None
 
     @field_validator("status")
     def validate_status(cls, value):

--- a/backend/app/services/clear_cut.py
+++ b/backend/app/services/clear_cut.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from geoalchemy2 import Geography
 from geoalchemy2.elements import WKTElement
-from geoalchemy2.functions import ST_AsGeoJSON, ST_Area, ST_Centroid
+from geoalchemy2.functions import ST_Area, ST_AsGeoJSON, ST_Centroid
 from shapely.geometry import MultiPolygon as ShapelyMultiPolygon
 from shapely.geometry import shape
 from sqlalchemy import cast, update
@@ -107,6 +107,9 @@ def update_clear_cut_geometry(
     clear_cut.is_manually_edited = True
     clear_cut.manually_edited_at = datetime.now()
     clear_cut.manually_edited_by_id = connected_user.id
+    # A fresh manual correction must re-lock the cut against the pipeline, even if
+    # the override had been re-enabled for a previous run.
+    clear_cut.allow_pipeline_override = False
     db.flush()
 
     if boundary_changed:

--- a/backend/app/services/clear_cut.py
+++ b/backend/app/services/clear_cut.py
@@ -1,9 +1,17 @@
-from geoalchemy2.functions import ST_AsGeoJSON
+from datetime import datetime
+
+from geoalchemy2 import Geography
+from geoalchemy2.elements import WKTElement
+from geoalchemy2.functions import ST_AsGeoJSON, ST_Area, ST_Centroid
+from shapely.geometry import MultiPolygon as ShapelyMultiPolygon
+from shapely.geometry import shape
+from sqlalchemy import cast, update
 from sqlalchemy.orm import Session
 
 from app.common.errors import AppHTTPException
-from app.models import ClearCut, ClearCutEcologicalZoning
+from app.models import SRID, ClearCut, ClearCutEcologicalZoning, User
 from app.schemas.clear_cut import (
+    ClearCutPatchSchema,
     ClearCutResponseSchema,
     clear_cut_to_clear_cut_response_schema,
 )
@@ -41,6 +49,84 @@ def get_clearcut_by_id(id: int, db: Session) -> ClearCutResponseSchema:
     return clear_cut_to_clear_cut_response_schema(
         map_geo_clearcut(clearcut, boundary, location)
     )
+
+
+def update_clear_cut_geometry(
+    db: Session,
+    clear_cut_id: int,
+    connected_user: User,
+    request: ClearCutPatchSchema,
+) -> ClearCutResponseSchema:
+    """Manually correct a clear cut's perimeter and/or observation dates.
+
+    Allowed for admins and the volunteer assigned to the parent report. Editing
+    the perimeter recomputes the area (hectares) and centroid server-side from
+    PostGIS, flags the cut as manually edited, and re-aggregates the report.
+    """
+    clear_cut = db.get(ClearCut, clear_cut_id)
+    if clear_cut is None:
+        raise AppHTTPException(
+            status_code=404, type="CLEAR_CUT_NOT_FOUND", detail="ClearCut not found"
+        )
+
+    report = clear_cut.report
+    if connected_user.role != "admin" and (
+        report is None or report.user_id != connected_user.id
+    ):
+        raise AppHTTPException(
+            status_code=403,
+            type="INVALID_REQUESTER_RIGHTS",
+            detail="Only admins or the assigned volunteer can edit a clear cut",
+        )
+
+    boundary_changed = request.boundary is not None
+    changed = boundary_changed
+
+    if boundary_changed:
+        geom = shape(request.boundary.model_dump())
+        if geom.geom_type == "Polygon":
+            geom = ShapelyMultiPolygon([geom])
+        elif geom.geom_type != "MultiPolygon":
+            raise AppHTTPException(
+                status_code=400,
+                type="INVALID_GEOMETRY",
+                detail="Perimeter must be a Polygon or MultiPolygon",
+            )
+        clear_cut.boundary = WKTElement(geom.wkt, srid=SRID)
+
+    if request.observation_start_date is not None:
+        clear_cut.observation_start_date = request.observation_start_date
+        changed = True
+    if request.observation_end_date is not None:
+        clear_cut.observation_end_date = request.observation_end_date
+        changed = True
+
+    if not changed:
+        return get_clearcut_by_id(clear_cut_id, db)
+
+    clear_cut.is_manually_edited = True
+    clear_cut.manually_edited_at = datetime.now()
+    clear_cut.manually_edited_by_id = connected_user.id
+    db.flush()
+
+    if boundary_changed:
+        # Derive area + centroid from the new perimeter (geography = metric area).
+        db.execute(
+            update(ClearCut)
+            .where(ClearCut.id == clear_cut_id)
+            .values(
+                area_hectare=ST_Area(cast(ClearCut.boundary, Geography)) / 10000.0,
+                location=ST_Centroid(ClearCut.boundary),
+            )
+        )
+
+    db.commit()
+
+    # Recompute report totals, first/last cut date, average location and rules.
+    from app.services.clear_cut_report import sync_clear_cuts_reports
+
+    sync_clear_cuts_reports(db)
+    return get_clearcut_by_id(clear_cut_id, db)
 
 
 def paginated_clear_cuts_query(db: Session, page: int = 0, size: int = 10):

--- a/backend/app/services/clear_cut_report.py
+++ b/backend/app/services/clear_cut_report.py
@@ -322,6 +322,52 @@ def update_clear_cut_report(
                 detail="Only admins can update report status directly",
             )
 
+    # Editing the initial report info (commune, date de signalement) is allowed
+    # for admins and for the volunteer assigned to the report.
+    edits_report_info = (
+        "reported_at" in request.model_fields_set
+        or "city_zip_code" in request.model_fields_set
+    )
+    if edits_report_info:
+        if connected_user.role != "admin" and report.user_id != connected_user.id:
+            raise AppHTTPException(
+                status_code=403,
+                type="INVALID_REQUESTER_RIGHTS",
+                detail="Only admins or the assigned volunteer can edit report info",
+            )
+        if "reported_at" in request.model_fields_set:
+            report.reported_at = request.reported_at
+        if "city_zip_code" in request.model_fields_set and request.city_zip_code:
+            report.city = get_city_by_zip_code(db, request.city_zip_code)
+
+    db.commit()
+    db.refresh(report)
+    return report
+
+
+def set_report_pipeline_override(
+    report_id: int, db: Session, connected_user: User, allow: bool
+) -> ClearCutReport:
+    """Toggle whether the data pipeline may overwrite the report's clear cuts.
+
+    Off by default once a cut has been manually edited, so corrections are not
+    lost on the next pipeline run. Admins or the assigned volunteer can flip it.
+    """
+    report = db.get(ClearCutReport, report_id)
+    if not report:
+        raise AppHTTPException(
+            status_code=404,
+            type="REPORT_NOT_FOUND",
+            detail="Clear cut report not found",
+        )
+    if connected_user.role != "admin" and report.user_id != connected_user.id:
+        raise AppHTTPException(
+            status_code=403,
+            type="INVALID_REQUESTER_RIGHTS",
+            detail="Only admins or the assigned volunteer can change this setting",
+        )
+    for clear_cut in report.clear_cuts:
+        clear_cut.allow_pipeline_override = allow
     db.commit()
     db.refresh(report)
     return report

--- a/data_pipeline/pipeline/scripts/db_export.py
+++ b/data_pipeline/pipeline/scripts/db_export.py
@@ -67,6 +67,8 @@ def get_export_query() -> str:
             cc.bdf_poplar_area_hectare as bdf_poplar_area_ha,
             cc.bdf_resinous_area_hectare as bdf_resinous_area_ha,
             ccr.slope_area_hectare as slope_area_ha,
+            cc.is_manually_edited as is_manually_edited,
+            cc.allow_pipeline_override as allow_pipeline_override,
             cc.boundary as geometry
         FROM clear_cuts cc
         LEFT JOIN clear_cuts_reports ccr ON cc.report_id = ccr.id
@@ -133,6 +135,8 @@ def reorder_columns(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
         "bdf_poplar_area_ha",
         "bdf_resinous_area_ha",
         "slope_area_ha",
+        "is_manually_edited",
+        "allow_pipeline_override",
         "geometry",
     ]
 

--- a/data_pipeline/pipeline/scripts/get_new_and_update.py
+++ b/data_pipeline/pipeline/scripts/get_new_and_update.py
@@ -5,6 +5,25 @@ from shapely.ops import unary_union
 from pipeline.scripts import DATA_DIR
 
 
+def locked_clusters_mask(gdf: gpd.GeoDataFrame) -> pd.Series:
+    """Reference clusters that were manually edited and must NOT be overwritten.
+
+    A cluster is locked when it has been corrected by hand
+    (``is_manually_edited``) and an admin has not re-enabled overriding
+    (``allow_pipeline_override`` is False). Locked clusters are excluded from the
+    matching buffer so the pipeline never merges new satellite detections into
+    them — those detections fall back to being brand-new clusters instead.
+    """
+    if "is_manually_edited" not in gdf.columns:
+        return pd.Series(False, index=gdf.index)
+    edited = gdf["is_manually_edited"].fillna(False).astype(bool)
+    if "allow_pipeline_override" in gdf.columns:
+        override = gdf["allow_pipeline_override"].fillna(False).astype(bool)
+    else:
+        override = pd.Series(False, index=gdf.index)
+    return edited & ~override
+
+
 def split_new_and_updated_clusters(gdf_new, gdf_ref, distance_threshold=50):
     """
     Sépare les nouveaux clusters en deux catégories :
@@ -42,8 +61,10 @@ def split_new_and_updated_clusters(gdf_new, gdf_ref, distance_threshold=50):
             "Attention: CRS géographique détecté. Reprojection en mètres recommandée."
         )
 
-    # Créer un buffer de 50m autour des géométries de référence
-    gdf_ref_buffered = gdf_ref.copy()
+    # Créer un buffer de 50m autour des géométries de référence.
+    # On exclut les clusters verrouillés (édités manuellement) pour que les
+    # nouvelles détections proches soient classées "new" plutôt que fusionnées.
+    gdf_ref_buffered = gdf_ref[~locked_clusters_mask(gdf_ref)].copy()
     gdf_ref_buffered["geometry"] = gdf_ref_buffered.geometry.buffer(distance_threshold)
 
     # Ajouter un index unique pour tracker les correspondances
@@ -122,8 +143,10 @@ def update_geometries(distance_threshold=50):
     # Copie pour ne pas modifier l'original
     gdf_ref_updated = gdf_ref.copy()
 
-    # Créer un buffer pour le matching
-    gdf_ref_buffered = gdf_ref.copy()
+    # Créer un buffer pour le matching.
+    # Les clusters verrouillés (édités manuellement) sont exclus : ils ne sont
+    # jamais matchés, donc préservés tels quels dans la référence finale.
+    gdf_ref_buffered = gdf_ref[~locked_clusters_mask(gdf_ref)].copy()
     gdf_ref_buffered["geometry"] = gdf_ref_buffered.geometry.buffer(distance_threshold)
 
     # Ajouter un index pour tracker

--- a/frontend/src/features/clear-cut/components/form/AccordionContent.tsx
+++ b/frontend/src/features/clear-cut/components/form/AccordionContent.tsx
@@ -7,6 +7,7 @@ import type { FormType } from "@/shared/form/types"
 
 import { actorsKey, actorsValue } from "./sections/ActorsSection"
 import { ecoZoneKey, ecoZoneValue } from "./sections/EcoZoneSection"
+import { GeneralInfoEditControls } from "./sections/GeneralInfoEditControls"
 import { generalInfoKey, generalInfoValue } from "./sections/GeneralInfoSection"
 import { legalKey, legalValue } from "./sections/LegalSection"
 import { onSiteKey, onSiteValue } from "./sections/OnSiteSection"
@@ -48,6 +49,9 @@ export default function AccordionContent({ form, original, latest }: Props) {
 							{sectionContent.map((item) => (
 								<AccordionItem form={form} item={item} key={item.name} />
 							))}
+							{section === generalInfoKey && (
+								<GeneralInfoEditControls form={form} />
+							)}
 						</AccordionFullItem>
 					</ChangeTrackingProvider>
 				)

--- a/frontend/src/features/clear-cut/components/form/sections/GeneralInfoEditControls.tsx
+++ b/frontend/src/features/clear-cut/components/form/sections/GeneralInfoEditControls.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/dialog"
 import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
+import { useMapInstance } from "@/features/clear-cut/components/map/Map.context"
 import type { ClearCutFormInput } from "@/features/clear-cut/store/clear-cuts"
 import {
 	setPipelineOverrideThunk,
@@ -57,6 +58,9 @@ export function GeneralInfoEditControls({
 	const user = useConnectedMe()
 	const dispatch = useAppDispatch()
 	const { toast } = useToast()
+	const { editingPerimeterReportId, setEditingPerimeterReportId } =
+		useMapInstance()
+	const isEditingPerimeter = editingPerimeterReportId === report.id
 
 	const canEdit = useMemo(() => {
 		if (!user) return false
@@ -307,6 +311,22 @@ export function GeneralInfoEditControls({
 						</DialogFooter>
 					</DialogContent>
 				</Dialog>
+			)}
+
+			{canEdit && singleCut && (
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					className="w-fit"
+					disabled={isEditingPerimeter}
+					onClick={() => setEditingPerimeterReportId(report.id)}
+				>
+					<Pencil size={14} className="mr-1" />
+					{isEditingPerimeter
+						? "Édition du périmètre en cours…"
+						: "Modifier le périmètre"}
+				</Button>
 			)}
 
 			{canEdit && report.isManuallyEdited && (

--- a/frontend/src/features/clear-cut/components/form/sections/GeneralInfoEditControls.tsx
+++ b/frontend/src/features/clear-cut/components/form/sections/GeneralInfoEditControls.tsx
@@ -1,0 +1,327 @@
+import { Pencil } from "lucide-react"
+import { useEffect, useId, useMemo, useState } from "react"
+import { FormattedDate } from "react-intl"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger
+} from "@/components/ui/dialog"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import type { ClearCutFormInput } from "@/features/clear-cut/store/clear-cuts"
+import {
+	setPipelineOverrideThunk,
+	updateClearCutGeometryThunk,
+	updateReportInfoThunk
+} from "@/features/clear-cut/store/clear-cuts-slice"
+import { getStoredToken, useConnectedMe } from "@/features/user/store/me.slice"
+import { useToast } from "@/hooks/use-toast"
+import { api } from "@/shared/api/api"
+import type { FormType } from "@/shared/form/types"
+import { useAppDispatch } from "@/shared/hooks/store"
+
+type CitySearchResult = {
+	insee_code: string
+	name: string
+	department_code: string
+}
+
+function authedApi() {
+	const token = getStoredToken() as { accessToken?: string } | null
+	return token?.accessToken
+		? api.extend({ headers: { Authorization: `Bearer ${token.accessToken}` } })
+		: api
+}
+
+const dateInputClass =
+	"flex h-10 w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+
+/**
+ * Lets admins and the assigned volunteer correct the initial report information
+ * (commune, date de signalement, dates de coupe) and signals/controls manual
+ * edition. Rendered inside the "Informations générales" accordion section.
+ */
+export function GeneralInfoEditControls({
+	form
+}: {
+	form: FormType<ClearCutFormInput>
+}) {
+	const report = form.watch("report")
+	const user = useConnectedMe()
+	const dispatch = useAppDispatch()
+	const { toast } = useToast()
+
+	const canEdit = useMemo(() => {
+		if (!user) return false
+		return user.role === "admin" || report.userId === user.id
+	}, [user, report.userId])
+
+	// Cut dates are stored per clear cut. When a report holds a single cut we can
+	// edit its observation window directly; with several cuts we only expose the
+	// report-level fields (perimeter/date edits are then done per cut on the map).
+	const singleCut =
+		report.clearCuts.length === 1 ? report.clearCuts[0] : undefined
+
+	const [open, setOpen] = useState(false)
+	const [reportedAt, setReportedAt] = useState(
+		report.reportedAt ?? report.createdAt
+	)
+	const [startDate, setStartDate] = useState(
+		singleCut?.observationStartDate ?? report.firstCutDate
+	)
+	const [endDate, setEndDate] = useState(
+		singleCut?.observationEndDate ?? report.lastCutDate
+	)
+	const [citySearch, setCitySearch] = useState("")
+	const [cityResults, setCityResults] = useState<CitySearchResult[]>([])
+	const [selectedCity, setSelectedCity] = useState<CitySearchResult | null>(
+		null
+	)
+	const [isSubmitting, setIsSubmitting] = useState(false)
+
+	const reportedAtId = useId()
+	const startDateId = useId()
+	const endDateId = useId()
+	const citySearchId = useId()
+	const overrideId = useId()
+
+	// Snapshot the dialog fields from fresh report data each time it opens.
+	const handleOpenChange = (next: boolean) => {
+		if (next) {
+			setReportedAt(report.reportedAt ?? report.createdAt)
+			setStartDate(singleCut?.observationStartDate ?? report.firstCutDate)
+			setEndDate(singleCut?.observationEndDate ?? report.lastCutDate)
+			setSelectedCity(null)
+			setCitySearch("")
+			setCityResults([])
+		}
+		setOpen(next)
+	}
+
+	useEffect(() => {
+		if (citySearch.length < 2) {
+			setCityResults([])
+			return
+		}
+		const timeout = setTimeout(async () => {
+			try {
+				const results = await authedApi()
+					.get("api/v1/cities/search", { searchParams: { q: citySearch } })
+					.json<CitySearchResult[]>()
+				setCityResults(results)
+			} catch {
+				setCityResults([])
+			}
+		}, 250)
+		return () => clearTimeout(timeout)
+	}, [citySearch])
+
+	if (!canEdit && !report.isManuallyEdited) {
+		return null
+	}
+
+	const handleSave = async () => {
+		setIsSubmitting(true)
+		try {
+			await dispatch(
+				updateReportInfoThunk({
+					reportId: report.id,
+					reportedAt,
+					cityZipCode: selectedCity?.insee_code
+				})
+			).unwrap()
+
+			if (
+				singleCut &&
+				(startDate !== singleCut.observationStartDate ||
+					endDate !== singleCut.observationEndDate)
+			) {
+				await dispatch(
+					updateClearCutGeometryThunk({
+						reportId: report.id,
+						clearCutId: singleCut.id,
+						observationStartDate: startDate,
+						observationEndDate: endDate
+					})
+				).unwrap()
+			}
+
+			toast({ id: "report-info-updated", title: "Informations mises à jour" })
+			setOpen(false)
+		} catch {
+			toast({
+				id: "report-info-error",
+				title: "Erreur lors de la mise à jour des informations"
+			})
+		} finally {
+			setIsSubmitting(false)
+		}
+	}
+
+	const handleToggleOverride = async (allow: boolean) => {
+		try {
+			await dispatch(
+				setPipelineOverrideThunk({ reportId: report.id, allow })
+			).unwrap()
+		} catch {
+			toast({
+				id: "pipeline-override-error",
+				title: "Erreur lors de la mise à jour du paramètre"
+			})
+		}
+	}
+
+	return (
+		<div className="flex flex-col gap-2 mt-2">
+			{report.isManuallyEdited && (
+				<Badge
+					variant="secondary"
+					className="w-fit gap-1 bg-amber-100 text-amber-800"
+				>
+					<Pencil size={12} />
+					Édité manuellement
+					{report.manuallyEditedAt && (
+						<>
+							{" le "}
+							<FormattedDate value={report.manuallyEditedAt} />
+						</>
+					)}
+				</Badge>
+			)}
+
+			{canEdit && (
+				<Dialog open={open} onOpenChange={handleOpenChange}>
+					<DialogTrigger asChild>
+						<Button type="button" variant="outline" size="sm" className="w-fit">
+							<Pencil size={14} className="mr-1" />
+							Modifier les informations
+						</Button>
+					</DialogTrigger>
+					<DialogContent className="sm:max-w-md">
+						<DialogHeader>
+							<DialogTitle>Modifier les informations</DialogTitle>
+							<DialogDescription>
+								Corrigez les informations initiales de la coupe.
+							</DialogDescription>
+						</DialogHeader>
+						<div className="flex flex-col gap-4 py-2">
+							<div className="flex flex-col gap-1">
+								<Label htmlFor={reportedAtId}>Date de signalement</Label>
+								<input
+									id={reportedAtId}
+									type="date"
+									className={dateInputClass}
+									value={reportedAt}
+									onChange={(e) => setReportedAt(e.target.value)}
+								/>
+							</div>
+							{singleCut ? (
+								<div className="grid grid-cols-2 gap-2">
+									<div className="flex flex-col gap-1">
+										<Label htmlFor={startDateId}>Début de la coupe</Label>
+										<input
+											id={startDateId}
+											type="date"
+											className={dateInputClass}
+											value={startDate}
+											onChange={(e) => setStartDate(e.target.value)}
+										/>
+									</div>
+									<div className="flex flex-col gap-1">
+										<Label htmlFor={endDateId}>Fin de la coupe</Label>
+										<input
+											id={endDateId}
+											type="date"
+											className={dateInputClass}
+											value={endDate}
+											onChange={(e) => setEndDate(e.target.value)}
+										/>
+									</div>
+								</div>
+							) : (
+								<p className="text-xs text-neutral-500">
+									Ce signalement regroupe plusieurs coupes : les dates de coupe
+									se modifient zone par zone sur la carte.
+								</p>
+							)}
+							<div className="flex flex-col gap-1">
+								<Label htmlFor={citySearchId}>Commune</Label>
+								<div className="relative">
+									<input
+										id={citySearchId}
+										placeholder={report.city}
+										value={
+											selectedCity
+												? `${selectedCity.name} (${selectedCity.department_code})`
+												: citySearch
+										}
+										onChange={(e) => {
+											setSelectedCity(null)
+											setCitySearch(e.target.value)
+										}}
+										autoComplete="off"
+										className={dateInputClass}
+									/>
+									{cityResults.length > 0 && !selectedCity && (
+										<ul className="absolute z-50 mt-1 w-full rounded-md border border-neutral-200 bg-white shadow-md max-h-48 overflow-y-auto">
+											{cityResults.map((city) => (
+												<li
+													key={city.insee_code}
+													className="cursor-pointer px-3 py-2 text-sm hover:bg-neutral-100"
+													onMouseDown={(e) => {
+														e.preventDefault()
+														setSelectedCity(city)
+														setCitySearch("")
+														setCityResults([])
+													}}
+												>
+													{city.name}
+													<span className="ml-1 text-neutral-400 text-xs">
+														({city.department_code})
+													</span>
+												</li>
+											))}
+										</ul>
+									)}
+								</div>
+							</div>
+						</div>
+						<DialogFooter>
+							<Button
+								variant="outline"
+								onClick={() => setOpen(false)}
+								disabled={isSubmitting}
+							>
+								Annuler
+							</Button>
+							<Button onClick={handleSave} disabled={isSubmitting}>
+								{isSubmitting ? "Enregistrement..." : "Enregistrer"}
+							</Button>
+						</DialogFooter>
+					</DialogContent>
+				</Dialog>
+			)}
+
+			{canEdit && report.isManuallyEdited && (
+				<div className="flex items-center gap-2 mt-1">
+					<Switch
+						id={overrideId}
+						checked={report.allowPipelineOverride ?? false}
+						onCheckedChange={handleToggleOverride}
+					/>
+					<Label htmlFor={overrideId} className="text-xs font-normal">
+						Autoriser la mise à jour automatique par le pipeline (écrase les
+						corrections manuelles)
+					</Label>
+				</div>
+			)}
+		</div>
+	)
+}

--- a/frontend/src/features/clear-cut/components/form/sections/GeneralInfoSection.tsx
+++ b/frontend/src/features/clear-cut/components/form/sections/GeneralInfoSection.tsx
@@ -31,7 +31,7 @@ export const generalInfoValue: SectionFormItem<ClearCutFormInput>[] = [
 			) : undefined
 	},
 	{
-		name: "report.updatedAt",
+		name: "report.reportedAt",
 		transformValue: ({ value }) => <FormattedDate value={value as string} />,
 		label: "Date de signalement",
 		type: "fixed",
@@ -50,13 +50,13 @@ export const generalInfoValue: SectionFormItem<ClearCutFormInput>[] = [
 		renderConditions: []
 	},
 	{
-		name: "report.averageLocation.coordinates.0",
+		name: "report.averageLocation.coordinates.1",
 		label: "Latitude",
 		type: "fixed",
 		renderConditions: []
 	},
 	{
-		name: "report.averageLocation.coordinates.1",
+		name: "report.averageLocation.coordinates.0",
 		label: "Longitude",
 		type: "fixed",
 		renderConditions: []

--- a/frontend/src/features/clear-cut/components/map/ClearCutPreview.tsx
+++ b/frontend/src/features/clear-cut/components/map/ClearCutPreview.tsx
@@ -1,24 +1,121 @@
 import { useLocation } from "@tanstack/react-router"
 import L from "leaflet"
-import { type RefObject, useEffect, useMemo, useRef } from "react"
+import { type RefObject, useEffect, useMemo, useRef, useState } from "react"
+import { createPortal } from "react-dom"
 import { GeoJSON, Marker } from "react-leaflet"
 
+import "@geoman-io/leaflet-geoman-free"
+import "@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.css"
+
+import { Button } from "@/components/ui/button"
 import { ClearCutMapPopUp } from "@/features/clear-cut/components/map/ClearCutMapPopUp"
 import { useMapInstance } from "@/features/clear-cut/components/map/Map.context"
 import { useNavigateToClearCut } from "@/features/clear-cut/hooks"
 import type {
 	ClearCut,
-	ClearCutReport
+	ClearCutReport,
+	MultiPolygon
 } from "@/features/clear-cut/store/clear-cuts"
+import { updateClearCutGeometryThunk } from "@/features/clear-cut/store/clear-cuts-slice"
 import { CLEAR_CUTTING_STATUS_COLORS } from "@/features/clear-cut/store/status"
+import { useToast } from "@/hooks/use-toast"
+import { useAppDispatch } from "@/shared/hooks/store"
 
 type Props = { report: ClearCutReport; clearCut: ClearCut }
 
+// Flatten an edited Leaflet GeoJSON output back into a single MultiPolygon.
+// biome-ignore lint/suspicious/noExplicitAny: Geoman/Leaflet GeoJSON is untyped
+function toMultiPolygon(geojson: any): MultiPolygon {
+	const coordinates: MultiPolygon["coordinates"] = []
+	// biome-ignore lint/suspicious/noExplicitAny: Geoman/Leaflet GeoJSON is untyped
+	const addGeometry = (geometry: any) => {
+		if (!geometry) return
+		if (geometry.type === "Polygon") coordinates.push(geometry.coordinates)
+		else if (geometry.type === "MultiPolygon")
+			coordinates.push(...geometry.coordinates)
+	}
+	if (geojson?.type === "FeatureCollection") {
+		for (const feature of geojson.features ?? []) addGeometry(feature.geometry)
+	} else if (geojson?.type === "Feature") {
+		addGeometry(geojson.geometry)
+	} else {
+		addGeometry(geojson)
+	}
+	return { type: "MultiPolygon", coordinates }
+}
+
 export function ClearCutPreview({ report, clearCut }: Props) {
-	const { setFocusedClearCutId, focusedClearCutId } = useMapInstance()
+	const {
+		setFocusedClearCutId,
+		focusedClearCutId,
+		editingPerimeterReportId,
+		setEditingPerimeterReportId
+	} = useMapInstance()
 	const ref = useRef<L.FeatureGroup>(null)
 	const location = useLocation()
 	const navigateToDetail = useNavigateToClearCut(report.id)
+	const dispatch = useAppDispatch()
+	const { toast } = useToast()
+	const [isSaving, setIsSaving] = useState(false)
+
+	const isEditingPerimeter = editingPerimeterReportId === report.id
+	// Kept in a ref so the (mount-time) click handlers always read the latest value.
+	const isEditingRef = useRef(isEditingPerimeter)
+	isEditingRef.current = isEditingPerimeter
+
+	// Enable/disable Geoman vertex editing on this layer when entering/leaving
+	// perimeter edit mode for this report.
+	useEffect(() => {
+		// biome-ignore lint/suspicious/noExplicitAny: Geoman augments Leaflet layers
+		const layer = ref.current as any
+		if (!layer?.eachLayer) return
+		// biome-ignore lint/suspicious/noExplicitAny: Geoman augments Leaflet layers
+		layer.eachLayer((child: any) => {
+			if (isEditingPerimeter) child.pm?.enable({ allowSelfIntersection: false })
+			else child.pm?.disable()
+		})
+	}, [isEditingPerimeter])
+
+	const handleSavePerimeter = async () => {
+		const layer = ref.current
+		if (!layer) return
+		setIsSaving(true)
+		try {
+			// biome-ignore lint/suspicious/noExplicitAny: Leaflet toGeoJSON is untyped
+			const boundary = toMultiPolygon((layer as any).toGeoJSON())
+			if (boundary.coordinates.length === 0) throw new Error("empty geometry")
+			await dispatch(
+				updateClearCutGeometryThunk({
+					reportId: report.id,
+					clearCutId: clearCut.id,
+					boundary
+				})
+			).unwrap()
+			toast({ id: "perimeter-saved", title: "Périmètre mis à jour" })
+			setEditingPerimeterReportId(undefined)
+		} catch {
+			toast({
+				id: "perimeter-error",
+				title: "Erreur lors de la mise à jour du périmètre"
+			})
+		} finally {
+			setIsSaving(false)
+		}
+	}
+
+	const handleCancelPerimeter = () => {
+		// biome-ignore lint/suspicious/noExplicitAny: Geoman augments Leaflet layers
+		const layer = ref.current as any
+		if (layer) {
+			// biome-ignore lint/suspicious/noExplicitAny: Geoman augments Leaflet layers
+			layer.eachLayer?.((child: any) => child.pm?.disable())
+			// Revert the on-screen edits by reloading the original geometry.
+			layer.clearLayers?.()
+			layer.addData?.(clearCut.boundary)
+		}
+		setEditingPerimeterReportId(undefined)
+	}
+
 	useEffect(() => {
 		if (focusedClearCutId === report.id) {
 			if (ref.current && (ref.current as any)._map) {
@@ -73,9 +170,11 @@ export function ClearCutPreview({ report, clearCut }: Props) {
 				}}
 				eventHandlers={{
 					dblclick: () => {
+						if (isEditingRef.current) return
 						navigateToDetail()
 					},
 					click: () => {
+						if (isEditingRef.current) return
 						navigateToDetail()
 					},
 					popupopen: () => {
@@ -88,15 +187,37 @@ export function ClearCutPreview({ report, clearCut }: Props) {
 					isReportPanelOpen={reportIsOpenInSideList}
 				/>
 			</GeoJSON>
-			<Marker
-				position={iconPosition}
-				icon={infoIcon}
-				interactive
-				keyboard={false}
-				eventHandlers={{
-					click: () => navigateToDetail()
-				}}
-			/>
+			{!isEditingPerimeter && (
+				<Marker
+					position={iconPosition}
+					icon={infoIcon}
+					interactive
+					keyboard={false}
+					eventHandlers={{
+						click: () => navigateToDetail()
+					}}
+				/>
+			)}
+			{isEditingPerimeter &&
+				createPortal(
+					<div className="fixed bottom-24 left-1/2 z-[1000] flex -translate-x-1/2 items-center gap-2 rounded-md border bg-white p-2 shadow-lg">
+						<span className="px-2 text-sm">
+							Déplacez les sommets pour ajuster le périmètre
+						</span>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={handleCancelPerimeter}
+							disabled={isSaving}
+						>
+							Annuler
+						</Button>
+						<Button size="sm" onClick={handleSavePerimeter} disabled={isSaving}>
+							{isSaving ? "Enregistrement…" : "Enregistrer le périmètre"}
+						</Button>
+					</div>,
+					document.body
+				)}
 		</>
 	)
 }

--- a/frontend/src/features/clear-cut/components/map/Map.context.tsx
+++ b/frontend/src/features/clear-cut/components/map/Map.context.tsx
@@ -5,6 +5,9 @@ export type MapContext = {
 	setMap: (map: L.Map | null) => void
 	focusedClearCutId?: string
 	setFocusedClearCutId: (id?: string) => void
+	/** Report whose perimeter is currently being edited on the map, if any. */
+	editingPerimeterReportId?: string
+	setEditingPerimeterReportId: (id?: string) => void
 } | null
 const MapCtx = createContext<MapContext>(null)
 
@@ -18,11 +21,15 @@ export const useMapInstance = () => {
 export const MapProvider = ({ children }: { children: React.ReactNode }) => {
 	const [map, setMap] = useState<L.Map | null>(null)
 	const [focusedClearCutId, setFocusedClearCutId] = useState<string>()
+	const [editingPerimeterReportId, setEditingPerimeterReportId] =
+		useState<string>()
 	return (
 		<MapCtx.Provider
 			value={{
 				focusedClearCutId,
 				setFocusedClearCutId,
+				editingPerimeterReportId,
+				setEditingPerimeterReportId,
 				map,
 				setMap
 			}}

--- a/frontend/src/features/clear-cut/store/clear-cuts-slice.ts
+++ b/frontend/src/features/clear-cut/store/clear-cuts-slice.ts
@@ -41,6 +41,7 @@ import {
 	clearCutFormVersionsSchema,
 	clearCutReportResponseSchema,
 	clearCutsResponseSchema,
+	type MultiPolygon,
 	myAssignedReportsResponseSchema
 } from "./clear-cuts"
 
@@ -52,6 +53,8 @@ const mapReport = (
 	report: ClearCutReportResponse
 ): ClearCutReport => ({
 	...report,
+	// "Date de signalement" defaults to the report creation date until corrected.
+	reportedAt: report.reportedAt ?? report.createdAt,
 	rules: selectRulesByIds(state, report.rulesIds),
 	department: selectDepartmentsByIds(state, [report.departmentId])[0],
 	clearCuts: report.clearCuts.map((cut) => ({
@@ -393,6 +396,70 @@ export const rejectValidationThunk = createAppAsyncThunk<void, string>(
 	}
 )
 
+export const updateClearCutGeometryThunk = createAppAsyncThunk<
+	void,
+	{
+		reportId: string
+		clearCutId: string
+		boundary?: MultiPolygon
+		observationStartDate?: string
+		observationEndDate?: string
+	}
+>(
+	"clear-cuts/updateGeometry",
+	async (
+		{
+			reportId,
+			clearCutId,
+			boundary,
+			observationStartDate,
+			observationEndDate
+		},
+		{ extra: { api }, dispatch }
+	) => {
+		const json: Record<string, unknown> = {}
+		if (boundary !== undefined) json.boundary = boundary
+		if (observationStartDate !== undefined)
+			json.observationStartDate = observationStartDate
+		if (observationEndDate !== undefined)
+			json.observationEndDate = observationEndDate
+		await api().patch(`api/v1/clear-cuts/${clearCutId}`, { json }).json()
+		dispatch(getClearCutFormThunk({ id: reportId, hasBeenCreated: true }))
+	}
+)
+
+export const updateReportInfoThunk = createAppAsyncThunk<
+	void,
+	{ reportId: string; reportedAt?: string; cityZipCode?: string }
+>(
+	"clear-cuts/updateReportInfo",
+	async (
+		{ reportId, reportedAt, cityZipCode },
+		{ extra: { api }, dispatch }
+	) => {
+		const json: Record<string, unknown> = {}
+		if (reportedAt !== undefined) json.reportedAt = reportedAt
+		if (cityZipCode !== undefined) json.cityZipCode = cityZipCode
+		await api().put(`api/v1/clear-cuts-reports/${reportId}`, { json })
+		dispatch(getClearCutFormThunk({ id: reportId, hasBeenCreated: true }))
+	}
+)
+
+export const setPipelineOverrideThunk = createAppAsyncThunk<
+	void,
+	{ reportId: string; allow: boolean }
+>(
+	"clear-cuts/setPipelineOverride",
+	async ({ reportId, allow }, { extra: { api }, dispatch }) => {
+		await api()
+			.post(`api/v1/clear-cuts-reports/${reportId}/pipeline-override`, {
+				json: { allow }
+			})
+			.json()
+		dispatch(getClearCutFormThunk({ id: reportId, hasBeenCreated: true }))
+	}
+)
+
 type State = {
 	clearCuts: RequestedContent<ClearCuts>
 	detail: RequestedContent<ClearCutFormVersions>
@@ -518,6 +585,21 @@ export const clearCutsSlice = createSlice({
 		addRequestedContentCases(
 			builder,
 			rejectValidationThunk,
+			(state) => state.assignation
+		)
+		addRequestedContentCases(
+			builder,
+			updateClearCutGeometryThunk,
+			(state) => state.assignation
+		)
+		addRequestedContentCases(
+			builder,
+			updateReportInfoThunk,
+			(state) => state.assignation
+		)
+		addRequestedContentCases(
+			builder,
+			setPipelineOverrideThunk,
 			(state) => state.assignation
 		)
 		builder.addCase(getMeThunk.fulfilled, (_, { payload: { favorites } }) => {

--- a/frontend/src/features/clear-cut/store/clear-cuts.ts
+++ b/frontend/src/features/clear-cut/store/clear-cuts.ts
@@ -43,7 +43,10 @@ export const clearCutResponseSchema = z.object({
 	observationStartDate: z.iso.date(),
 	observationEndDate: z.iso.date(),
 	ecologicalZoningIds: z.string().array(),
-	areaHectare: z.number()
+	areaHectare: z.number(),
+	isManuallyEdited: z.boolean().optional(),
+	manuallyEditedAt: z.iso.date().optional().nullable(),
+	allowPipelineOverride: z.boolean().optional()
 })
 export type ClearCutResponse = z.infer<typeof clearCutResponseSchema>
 const clearCutSchema = clearCutResponseSchema
@@ -74,6 +77,10 @@ export const clearCutReportResponseSchema = z.object({
 	departmentId: z.string(),
 	createdAt: z.iso.date(),
 	updatedAt: z.iso.date(),
+	reportedAt: z.iso.date().optional().nullable(),
+	isManuallyEdited: z.boolean().optional(),
+	manuallyEditedAt: z.iso.date().optional().nullable(),
+	allowPipelineOverride: z.boolean().optional(),
 	totalAreaHectare: z.number(),
 	totalBdfResinousAreaHectare: z.number().optional(),
 	totalBdfDeciduousAreaHectare: z.number().optional(),

--- a/frontend/src/test/features/clear-cut/form.browser.test.tsx
+++ b/frontend/src/test/features/clear-cut/form.browser.test.tsx
@@ -142,6 +142,15 @@ const setupTest = (
 			case "report.updatedAt":
 				expected = "13/03/2026"
 				break
+			case "report.reportedAt": {
+				// "Date de signalement" falls back to createdAt and renders via
+				// <FormattedDate> as dd/MM/yyyy.
+				const iso =
+					(expected as string | undefined) ?? formReport.report.createdAt
+				const [year, month, day] = String(iso).split("-")
+				expected = `${day}/${month}/${year}`
+				break
+			}
 			case "report.lastCutDate":
 				expected = "19/03/2024"
 				break
@@ -196,7 +205,10 @@ const defaultSetupServerBeforeEach = (setup: ReturnType<typeof setupTest>) => {
 		worker.use(setup.reportMock.handler, setup.formMock.handler)
 	})
 }
-const setupVolunteerAssigned = setupTest({ affectedUser: volunteerMock, status: "in_progress" })
+const setupVolunteerAssigned = setupTest({
+	affectedUser: volunteerMock,
+	status: "in_progress"
+})
 describe.each(setupVolunteerAssigned.sections)(
 	"$section.name section form when there is volunteer assigned",
 	({ section, items }) => {


### PR DESCRIPTION


https://github.com/user-attachments/assets/0368fcb0-7567-44f8-a841-ab63707b9447




## Contexte

Résout #240 : permettre la modification des informations initiales (renseignées à la création de la coupe) et du périmètre détecté par satellite, le périmètre devant rester modifiable par la suite.

Au passage, deux bugs d'affichage repérés sur le panneau « Informations générales » sont corrigés.

## Bugs corrigés

- **Latitude / Longitude inversées** : le GeoJSON renvoie `[longitude, latitude]`, mais les libellés étaient intervertis.
- **Date de signalement** : pointait sur `updated_at` (volatil, change à chaque sync/édition). Elle s'appuie désormais sur un champ `reported_at` éditable, avec repli sur `created_at`.

## Fonctionnalités

### Édition des informations initiales
Dialogue « Modifier les informations » dans la section Informations générales : date de signalement, début/fin de coupe et commune. Accessible aux admins et au bénévole assigné au signalement.

### Édition du périmètre
Bouton « Modifier le périmètre » → mode édition Geoman sur le polygone (déplacement des sommets), avec une barre Enregistrer / Annuler sur la carte. À l'enregistrement, la nouvelle géométrie est envoyée au backend, qui **recalcule l'aire et le centroïde via PostGIS**.

### Protection contre l'écrasement par le pipeline
Toute correction manuelle marque la coupe comme `is_manually_edited`. Le pipeline qui tourne régulièrement **exclut les coupes verrouillées** du matching : les corrections ne sont jamais écrasées. Un toggle (off par défaut) permet de réautoriser la mise à jour automatique au prochain run.

## Détails techniques

**Backend**
- `ClearCut` : `is_manually_edited`, `manually_edited_at`, `manually_edited_by_id`, `allow_pipeline_override` ; `ClearCutReport` : `reported_at`. Migration `a1b2c3d4e5f6`.
- `PATCH /api/v1/clear-cuts/{id}` : périmètre + dates d'observation, recalcul aire/centroïde, ré-agrégation du report. Droits : admin ou bénévole assigné.
- `PUT /api/v1/clear-cuts-reports/{id}` étendu : `reported_at` + commune.
- `POST /api/v1/clear-cuts-reports/{id}/pipeline-override`.

**Pipeline**
- Export des flags + exclusion des coupes verrouillées du matching (`db_export.py`, `get_new_and_update.py`).

**Frontend**
- Schémas, thunks (`updateClearCutGeometry`, `updateReportInfo`, `setPipelineOverride`), dialogue d'édition, badge « édité manuellement », toggle pipeline, édition de périmètre via Geoman.

## Vérifications

- Frontend : `tsc` ✓, Biome ✓, 264 tests browser ✓, `pnpm build` ✓.
- Backend : à valider en CI/Docker (`alembic upgrade head` + `make test`) — non exécutable sur mon poste local.

## À vérifier en revue

- Migration et tests backend en environnement Docker.
- Interaction Geoman ↔ couche GeoJSON pour l'édition de périmètre (à essayer dans l'app : ouvrir une coupe → Modifier le périmètre → déplacer un sommet → Enregistrer).