### PR TITLE
fix-retour : corrections formulaire, carte, auth, seed de dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,29 @@ docker compose up                   # Full stack
 - pgAdmin (DB Management): http://localhost:8888 (`devuser@devuser.com` / `devuser`)
 - Mailpit: http://localhost:8025
 
+### Dev seed dataset (`backend/seed_dev.py`)
+
+`seed_dev.py` wipes and reseeds a realistic fixture set built around four real
+forested departments — **Landes (40)**, **Lozère (48)**, **Creuse (23)**,
+**Vosges (88)** — with real communes and Natura 2000 zones that actually overlap
+the clear cuts.
+
+- **Users** (all volunteers share the password `volunteer`):
+  - `admin@example.com` / `admin` — admin, all four departments
+  - `volunteer@example.com` — Alice, Landes (40)
+  - `bruno@example.com` — Bruno, Lozère (48)
+  - `chloe@example.com` — Chloé, Creuse (23) + Vosges (88)
+  - `david@example.com` — David, **inactive** account (Vosges)
+- **14 reports** covering every status, every forest profile (résineux /
+  feuillus / mixte / peupleraie / inconnu), mono- and multi-cut reports, rule
+  edge cases (area / slope / ecological zoning above and below thresholds), one
+  unassigned report with a pending assignment request (Bruno), and a wide spread
+  of cut dates for the date sort.
+- **3 forms**: two fully filled (Mende, La Bresse) + one partial draft
+  (Labouheyre). Form images are copied into `backend/uploads/reports/<id>/` so
+  they render instead of pointing at broken filenames.
+- **Favorites** pre-set for Alice, Bruno and the admin.
+
 > **Mac ARM64 note:** The `.venv` inside the backend container is protected by an anonymous Docker volume (`/app/.venv`). Do not remove the `- /app/.venv` volume entry from `docker-compose.yml`.
 
 ### Backend (local, no Docker)
@@ -47,7 +70,7 @@ docker compose up                   # Full stack
 cd backend
 poetry install --with backend
 poetry run alembic upgrade head
-poetry run python -m seed_dev       # dev seed (admin@example.com / password, volunteer@example.com / password)
+poetry run python -m seed_dev       # dev seed (admin@example.com / admin, volunteer@example.com / volunteer)
 make devserver                      # starts on port 8080
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 - [Analytics](./analytics/README.md)
 - [Documentation](./doc/README.md)
 
+> 🚀 **Tu veux juste lancer le projet ?** Saute directement au guide pas à pas :
+> [Lancer le projet en local](#-lancer-le-projet-en-local-guide-pas-à-pas).
+
 # Contexte du Projet
 
 La déforestation et les coupes rases illégales représentent une menace majeure pour les écosystèmes et la biodiversité. Cependant, il existe un manque de transparence et de contrôle efficace sur ces pratiques, rendant difficile leur suivi et leur régulation.
@@ -241,83 +244,150 @@ Considérez la base de données keepass comme étant la golden source de tous le
 Chaque secret utilisés dans le projet doit être référencé dans le keepass.  
 Exemples de secrets à utiliser dans la base : mot de passe du compte gérant l'infrastructure cloud, CI/CD, clés d'API, chaines de connection pour base de données etc ...
 
-# Les commandes pour développer en local
+# 🚀 Lancer le projet en local (guide pas à pas)
 
-Quelques commandes pour démarrer le projet en local.
-Voir les README des sous-répertoires pour plus de détails sur chaque partie du projet.
+Cette section explique comment faire tourner **toute la stack** (base de données + backend + frontend) sur ta machine, de zéro.
 
-## Base de données
+## 0. Prérequis
 
-Prérequis : [Docker](https://docs.docker.com/get-docker/) et [Docker Compose](https://docs.docker.com/compose/install/)
+| Outil | Pour quoi faire | Obligatoire ? |
+| --- | --- | --- |
+| [Docker](https://docs.docker.com/get-docker/) + [Docker Compose](https://docs.docker.com/compose/install/) | Base de données, et toute la stack en Docker | ✅ Toujours |
+| [Python 3.13+](https://www.python.org/downloads/) + [Poetry](https://python-poetry.org/docs/#installation) | Lancer le backend **en local** (Option B) | Option B uniquement |
+| [Node.js 23+](https://nodejs.org/en) + [pnpm](https://pnpm.io/installation) | Lancer le frontend **en local** (Option B) | Option B uniquement |
+
+Il y a **deux façons** de lancer le projet. Choisis-en une :
+
+- **Option A — Tout en Docker** : une seule commande, rien à installer à part Docker. **Recommandé, surtout sur Mac.**
+- **Option B — En local, étape par étape** : DB en Docker, backend et frontend lancés à la main (utile pour développer/debugger).
+
+---
+
+## Option A — Tout en Docker (recommandé) 🐳
+
+Une seule commande construit les images, attend que Postgres soit prêt, applique les migrations, seede les données de dev et démarre tous les services :
 
 ```bash
-# Lancer PostgreSQL et pgAdmin
-docker compose up db pgadmin
+./start_docker.sh
 ```
 
-La base de données est accessible à l'adresse [http://localhost:5432](http://localhost:5432).
-Connectez-vous à pgAdmin sur [http://localhost:8888/](http://localhost:8888/) avec les identifiants suivants :
+Une fois terminé, tout tourne :
 
-- Email : `devuser@devuser.com`
-- Mot de passe : `devuser`
+| Service | URL | Identifiants |
+| --- | --- | --- |
+| Frontend (web) | http://localhost:8081 | voir [comptes de test](#comptes-de-test) |
+| Backend (API + docs Swagger) | http://localhost:8080/docs | — |
+| pgAdmin (gestion DB) | http://localhost:8888 | `devuser@devuser.com` / `devuser` |
+| Mailpit (emails de dev) | http://localhost:8025 | — |
 
-Ensuite, vous pouvez ajouter un nouveau serveur avec les informations suivantes :
-
-- Nom : `Dev Localhost`
-- Hôte : `db`
-- Port : `5432`
-- Maintenance database : `postgres`
-- Username : `devuser`
-- Password : `devuser`
-
-## Backend
-
-Prérequis : [Python 3.13+](https://www.python.org/downloads/) et [Poetry](https://python-poetry.org/docs/#installation)
+Commandes utiles :
 
 ```bash
-# Aller dans le répertoire backend
+docker compose logs -f          # suivre les logs de tous les services
+docker compose down             # tout arrêter (les données sont conservées)
+docker compose down -v          # tout arrêter ET supprimer la base de données
+```
+
+> ⚠️ **Mac (puce Apple) :** garde l'entrée de volume `- /app/.venv` dans `docker-compose.yml`. Elle protège l'environnement virtuel du backend dans le conteneur ; le retirer casse le démarrage.
+
+---
+
+## Option B — En local, étape par étape 🔧
+
+### Étape 1 — Base de données (toujours en Docker)
+
+```bash
+# Démarre PostgreSQL/PostGIS + pgAdmin et attend que la DB soit "healthy"
+docker compose up -d --wait db
+docker compose up -d pgadmin
+```
+
+- La base écoute sur le port `5432` (connexion : `postgresql://devuser:devuser@localhost:5432/local`).
+- pgAdmin est dispo sur http://localhost:8888 (`devuser@devuser.com` / `devuser`).
+  Pour y ajouter le serveur : Hôte `db`, Port `5432`, Username/Password `devuser`, Maintenance database `postgres`.
+
+### Étape 2 — Backend (API)
+
+```bash
 cd backend
 
-# Installer les dépendances
+# Installer les dépendances Python
 poetry install
 
-# Activer l'environnement virtuel
-source .venv/bin/activate
-
-# Mettre à jour les tables de la base de données avec Alembic
+# Appliquer les migrations (crée/maj les tables)
 poetry run alembic upgrade head
 
-# Seeder la base de données avec des données de développement
+# Seeder la base avec un jeu de données de dev complet (voir plus bas)
 poetry run python -m seed_dev
 
-# Lancer le serveur de développement
+# Lancer le serveur de dev (rechargement auto)
 poetry run python -m app.main --host='0.0.0.0' --port=8080 --reload --proxy-headers --forwarded-allow-ips='*'
 ```
 
-L'API du backend est accessible à l'adresse [http://localhost:8080](http://localhost:8080/docs)
+L'API et sa documentation Swagger sont sur http://localhost:8080/docs.
 
-## Frontend
+> 💡 Astuce : `make devserver` (dans `backend/`) lance la même commande de serveur.
 
-Prérequis : [Node.js 23+](https://nodejs.org/en) et [pnpm](https://pnpm.io/installation)
+### Étape 3 — Frontend (interface web)
+
+Dans un **deuxième terminal** (laisse le backend tourner) :
 
 ```bash
-# Aller dans le répertoire frontend
 cd frontend
 
 # Installer les dépendances
 pnpm i
 
-# Lancer le serveur de développement
+# Lancer le serveur de dev (tape le vrai backend sur :8080)
 pnpm dev
-
-# Pour construire le projet pour la production et vérifier le typing
-pnpm run build
-
-# Pour lancer les tests
-pnpm test
 ```
 
-Le site web est accessible à l'adresse [http://localhost:5173](http://localhost:5173)
+Le site est sur http://localhost:5173.
+
+Autres commandes frontend utiles :
+
+```bash
+pnpm dev:mock     # lance le front avec des mocks (MSW), sans backend
+pnpm build        # build de prod + vérification du typage
+pnpm test         # tests unitaires (Vitest)
+pnpm cleanup      # formatage + lint (Biome)
+```
+
+### Étape 4 — Vérifier que tout marche
+
+1. Ouvre http://localhost:5173, connecte-toi avec un [compte de test](#comptes-de-test).
+2. La carte doit afficher des coupes rases dans les Landes, la Lozère, la Creuse et les Vosges.
+3. L'API répond sur http://localhost:8080/docs.
+
+> 🍎 **macOS** : le script `./start_local.sh` automatise l'Option B (DB + migrations + seed, puis ouvre le backend et le frontend dans deux fenêtres Terminal).
+
+---
+
+## Comptes de test
+
+Le seed de dev crée ces comptes (tous les bénévoles ont le mot de passe `volunteer`) :
+
+| Email | Mot de passe | Rôle | Départements |
+| --- | --- | --- | --- |
+| `admin@example.com` | `admin` | admin | Landes, Lozère, Creuse, Vosges |
+| `volunteer@example.com` | `volunteer` | bénévole | Landes (40) |
+| `bruno@example.com` | `volunteer` | bénévole | Lozère (48) |
+| `chloe@example.com` | `volunteer` | bénévole | Creuse (23) + Vosges (88) |
+| `david@example.com` | `volunteer` | bénévole **inactif** | Vosges (88) |
+
+## Jeu de données de dev (`seed_dev`)
+
+`poetry run python -m seed_dev` **vide puis recrée** un jeu de données réaliste : 4 départements forestiers, communes et zones Natura 2000 réelles, 14 signalements couvrant tous les statuts et types de forêt, des cas limites pour les règles (surface/pente/zonage), une demande d'assignation en attente, des favoris et des formulaires (dont un avec photos). Détails complets dans [CLAUDE.md](./CLAUDE.md#dev-seed-dataset-backendseed_devpy).
+
+Pour repartir d'une base fraîche à tout moment :
+
+```bash
+# En local
+cd backend && poetry run python -m seed_dev
+
+# En Docker
+docker compose exec backend poetry run python -m seed_dev
+```
 
 ## Data pipeline
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -62,6 +62,11 @@ class Settings(BaseSettings):
         json_schema_extra={"env": "S3_ENDPOINT"},
         description="Endpoint URL of the S3 bucket for photos storage",
     )
+    MAX_UPLOAD_SIZE_BYTES: int = Field(
+        default=25 * 1024 * 1024,
+        json_schema_extra={"env": "MAX_UPLOAD_SIZE_BYTES"},
+        description="Maximum allowed size per uploaded photo, in bytes (default 25 MB)",
+    )
 
 
 settings = Settings()  # type: ignore[call-arg]

--- a/backend/app/routes/clear_cuts_map.py
+++ b/backend/app/routes/clear_cuts_map.py
@@ -132,6 +132,18 @@ def get_clearcuts_map(
         description="List of report ids to exclude",
         openapi_examples={"default": {"value": ["1"]}},
     ),
+    sort_by: str = Query(
+        "first_cut_date",
+        alias="sortBy",
+        description="Field to sort the report previews by",
+        openapi_examples={"default": {"value": "first_cut_date"}},
+    ),
+    sort_order: str = Query(
+        "desc",
+        alias="sortOrder",
+        description="Sort direction: 'asc' or 'desc'",
+        openapi_examples={"default": {"value": "desc"}},
+    ),
     db: Session = db_session,
 ) -> ClearCutMapResponseSchema:
     t = time()
@@ -164,6 +176,8 @@ def get_clearcuts_map(
                 excessive_slope=excessive_slope,
                 in_reports_ids=in_reports_ids,
                 out_reports_ids=out_reports_ids,
+                sort_by=sort_by,
+                sort_order=sort_order,
             ),
         )
 

--- a/backend/app/routes/images.py
+++ b/backend/app/routes/images.py
@@ -68,7 +68,7 @@ def generate_upload_url(
             detail=f"Type de fichier non autorisé. Types acceptés : {ALLOWED_TYPES}",
         )
 
-    max_size = 10 * 1024 * 1024
+    max_size = settings.MAX_UPLOAD_SIZE_BYTES
     if upload_request.file_size and upload_request.file_size > max_size:
         raise AppHTTPException(
             status_code=400,

--- a/backend/app/services/clear_cut_map.py
+++ b/backend/app/services/clear_cut_map.py
@@ -58,6 +58,8 @@ class Filters(BaseSchema):
     excessive_slope: bool | None = None
     in_reports_ids: list[str] | None = []
     out_reports_ids: list[str] | None = []
+    sort_by: str = "first_cut_date"
+    sort_order: str = "desc"
 
 
 def query_clearcuts_filtered(db: Session, filters: Filters | None):
@@ -266,7 +268,17 @@ def build_clearcuts_map(
             # If area doesnt exists clusters are useless
             clusterized_points = process_points_from_reports(reports_with_filters)
 
-    reports_with_filters = reports_with_filters.limit(30).all()
+    sortable_columns = {
+        "first_cut_date": ClearCutReport.first_cut_date,
+        "last_cut_date": ClearCutReport.last_cut_date,
+    }
+    sort_column = sortable_columns.get(filters.sort_by, ClearCutReport.first_cut_date)
+    sort_direction = (
+        sort_column.asc() if filters.sort_order == "asc" else sort_column.desc()
+    )
+    reports_with_filters = (
+        reports_with_filters.order_by(sort_direction).limit(30).all()
+    )
     map_response = ClearCutMapResponseSchema(
         points=clusterized_points,
         previews=list(map(report_to_report_preview_schema, reports_with_filters)),

--- a/backend/app/services/clear_cut_map.py
+++ b/backend/app/services/clear_cut_map.py
@@ -276,9 +276,7 @@ def build_clearcuts_map(
     sort_direction = (
         sort_column.asc() if filters.sort_order == "asc" else sort_column.desc()
     )
-    reports_with_filters = (
-        reports_with_filters.order_by(sort_direction).limit(30).all()
-    )
+    reports_with_filters = reports_with_filters.order_by(sort_direction).limit(30).all()
     map_response = ClearCutMapResponseSchema(
         points=clusterized_points,
         previews=list(map(report_to_report_preview_schema, reports_with_filters)),

--- a/backend/app/services/s3.py
+++ b/backend/app/services/s3.py
@@ -43,7 +43,7 @@ class S3Service:
         content_type: str,
         report_id: str | None = None,
         expires_in: int = 3600,
-        max_file_size: int = 10 * 1024 * 1024,  # 10MB default
+        max_file_size: int = settings.MAX_UPLOAD_SIZE_BYTES,
     ) -> dict:
         """
         Generate a pre-signed URL for uploading a file to S3

--- a/backend/common_seed.py
+++ b/backend/common_seed.py
@@ -4,6 +4,26 @@ from sqlalchemy.orm import Session
 
 from app.models import City, Department, EcologicalZoning, Rules
 
+# INSEE codes (column COM in cities_2024.csv) of the forest communes used by the
+# dev seed. They are picked in real, heavily forested French departments so that
+# clear cuts, Natura 2000 zones and department-based filters stay geographically
+# consistent (unlike the previous Paris/Marseille fixtures).
+SEED_CITY_CODES = {
+    # Landes (40) — Forêt des Landes de Gascogne, pinède => résineux, faible pente
+    "sabres": "40246",
+    "labouheyre": "40134",
+    "morcenx": "40197",
+    # Lozère (48) — Mont Lozère, forêt mixte, forte pente
+    "mende": "48095",
+    "pont_de_montvert": "48116",
+    # Creuse (23) — plateau de Millevaches, feuillus
+    "aubusson": "23008",
+    "royere": "23165",
+    # Vosges (88) — massif vosgien, mixte/résineux, forte pente
+    "gerardmer": "88196",
+    "la_bresse": "88075",
+}
+
 
 def seed_cities_departments(db: Session):
     if db.query(Department).first() is not None and db.query(City).first() is not None:
@@ -33,30 +53,51 @@ def seed_cities_departments(db: Session):
             return departments
 
 
-def get_cities(db: Session) -> list[City]:
-    marseille = db.query(City).filter(City.zip_code == "13055").first()
-    paris = db.query(City).filter(City.zip_code == "75056").first()
-    return [city for city in [marseille, paris] if city is not None]
+def get_cities(db: Session) -> dict[str, City]:
+    """Return the dev seed communes keyed by their short name (see SEED_CITY_CODES)."""
+    cities = db.query(City).filter(City.zip_code.in_(SEED_CITY_CODES.values())).all()
+    by_code = {city.zip_code: city for city in cities}
+    return {
+        name: by_code[code]
+        for name, code in SEED_CITY_CODES.items()
+        if code in by_code
+    }
 
 
-def seed_ecological_zonings(db: Session) -> tuple[EcologicalZoning, EcologicalZoning]:
-    ecological_zonings = [
-        EcologicalZoning(
+def seed_ecological_zonings(db: Session) -> dict[str, EcologicalZoning]:
+    """Real Natura 2000 zones, one per forest region used by the dev seed."""
+    zonings = {
+        "landes": EcologicalZoning(
             type="Natura2000",
             sub_type="ZSC",
-            code="FR1100796",
-            name="Forêt de Rambouillet",
+            code="FR7200721",
+            name="Vallées de la Grande et de la Petite Leyre",
         ),
-        EcologicalZoning(
-            type="Natura2000", code="FR5300050", name="Etands de canal d'Ille et Rance"
+        "lozere": EcologicalZoning(
+            type="Natura2000",
+            sub_type="ZSC",
+            code="FR9101368",
+            name="Mont Lozère",
         ),
-    ]
-    db.add_all(ecological_zonings)
+        "creuse": EcologicalZoning(
+            type="Natura2000",
+            sub_type="ZSC",
+            code="FR7401131",
+            name="Gorges de la Grande Creuse",
+        ),
+        "vosges": EcologicalZoning(
+            type="Natura2000",
+            sub_type="ZPS",
+            code="FR4112003",
+            name="Massif vosgien",
+        ),
+    }
+    db.add_all(zonings.values())
     db.flush()
-    return (ecological_zonings[0], ecological_zonings[1])
+    return zonings
 
 
-def seed_rules(db: Session, ecological_zonings: list[EcologicalZoning]):
+def seed_rules(db: Session, ecological_zonings: list[EcologicalZoning]) -> list[Rules]:
     rules = [
         Rules(
             type="area",
@@ -69,9 +110,9 @@ def seed_rules(db: Session, ecological_zonings: list[EcologicalZoning]):
         Rules(
             type="ecological_zoning",
             threshold=0.5,
-            ecological_zonings=ecological_zonings,
+            ecological_zonings=list(ecological_zonings),
         ),
     ]
     db.add_all(rules)
     db.flush()
-    return (ecological_zonings[0], ecological_zonings[1])
+    return rules

--- a/backend/common_seed.py
+++ b/backend/common_seed.py
@@ -58,9 +58,7 @@ def get_cities(db: Session) -> dict[str, City]:
     cities = db.query(City).filter(City.zip_code.in_(SEED_CITY_CODES.values())).all()
     by_code = {city.zip_code: city for city in cities}
     return {
-        name: by_code[code]
-        for name, code in SEED_CITY_CODES.items()
-        if code in by_code
+        name: by_code[code] for name, code in SEED_CITY_CODES.items() if code in by_code
     }
 
 

--- a/backend/seed_dev.py
+++ b/backend/seed_dev.py
@@ -264,7 +264,9 @@ def seed_database():
             status="in_progress",
             user=alice,
             clear_cuts=[  # multi-cut, total 13 ha => area rule
-                cut("labouheyre", area=7, forest="resinous", days_start=20, days_end=10),
+                cut(
+                    "labouheyre", area=7, forest="resinous", days_start=20, days_end=10
+                ),
                 cut(
                     "labouheyre",
                     area=6,

--- a/backend/seed_dev.py
+++ b/backend/seed_dev.py
@@ -1,7 +1,9 @@
 import math
 import os
+import shutil
 import traceback
 from datetime import datetime, timedelta
+from pathlib import Path
 
 from geoalchemy2.shape import from_shape
 from shapely.geometry import MultiPolygon, Point
@@ -26,6 +28,20 @@ from common_seed import (
 
 SRID = 4326
 
+# Approximate centroids (longitude, latitude) of the forest communes seeded in
+# common_seed.SEED_CITY_CODES. Used to place realistic clear-cut polygons.
+COMMUNE_COORDS = {
+    "sabres": (-0.728, 44.143),
+    "labouheyre": (-0.918, 44.211),
+    "morcenx": (-0.912, 44.033),
+    "mende": (3.500, 44.518),
+    "pont_de_montvert": (3.758, 44.360),
+    "aubusson": (2.165, 45.957),
+    "royere": (1.943, 45.838),
+    "gerardmer": (6.878, 48.073),
+    "la_bresse": (6.876, 48.001),
+}
+
 # Forest composition profiles expressed as fractions of area_hectare.
 # Sums stay < 1 so the bdf_area_smaller_than_clear_cut_area constraint always passes.
 FOREST_PROFILES = {
@@ -35,6 +51,11 @@ FOREST_PROFILES = {
     "poplar": {"resinous": 0.00, "deciduous": 0.05, "mixed": 0.05, "poplar": 0.85},
     "unknown": None,
 }
+
+# Sample image bundled with the repo, reused so seeded forms display real pictures
+# instead of the broken fake filenames the previous seed referenced.
+UPLOADS_DIR = Path("uploads")
+SAMPLE_IMAGE = UPLOADS_DIR / "67bf9395-0f14-433a-a131-7f46c52a5b19_test.jpg"
 
 
 def _hex_around(lng: float, lat: float, radius: float = 0.003):
@@ -86,6 +107,48 @@ def make_clear_cut(
     )
 
 
+def cut(
+    commune: str,
+    *,
+    area: float,
+    forest: str = "unknown",
+    days_start: int,
+    days_end: int,
+    eco_area: float | None = None,
+    zonings: list | None = None,
+    dx: float = 0.0,
+    dy: float = 0.0,
+) -> ClearCut:
+    """Build a clear cut near a named commune (with optional offset to avoid overlaps)."""
+    lng, lat = COMMUNE_COORDS[commune]
+    return make_clear_cut(
+        lng + dx,
+        lat + dy,
+        area_hectare=area,
+        forest_type=forest,
+        days_ago_start=days_start,
+        days_ago_end=days_end,
+        ecological_zoning_area=eco_area,
+        ecological_zonings=zonings,
+    )
+
+
+def seed_report_image(report_id: int, name: str) -> str | None:
+    """Copy the sample image into the report folder and return its storage key.
+
+    Returns None if the sample image is missing so seeding stays resilient.
+    """
+    if not SAMPLE_IMAGE.exists():
+        return None
+    dest_dir = UPLOADS_DIR / "reports" / str(report_id)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    filename = f"seed_{name}.jpg"
+    dest = dest_dir / filename
+    if not dest.exists():
+        shutil.copyfile(SAMPLE_IMAGE, dest)
+    return f"local/reports/{report_id}/{filename}"
+
+
 def wipe_database():
     env = os.environ.get("ENVIRONMENT", "development").lower()
     if env != "development" and env != "test":
@@ -107,9 +170,19 @@ def seed_database():
     try:
         wipe_database()
         seed_cities_departments(db)
-        [marseille, paris] = get_cities(db)
-        [natura1, natura2] = seed_ecological_zonings(db)
-        seed_rules(db, [natura1, natura2])
+        cities = get_cities(db)
+        zonings = seed_ecological_zonings(db)
+        seed_rules(db, list(zonings.values()))
+
+        # --- Users -------------------------------------------------------------
+        # One multi-department admin, three volunteers with disjoint departments
+        # (to exercise the department filter and "Actions requises"), and one
+        # inactive volunteer to cover account management.
+        landes = cities["sabres"].department
+        lozere = cities["mende"].department
+        creuse = cities["aubusson"].department
+        vosges = cities["gerardmer"].department
+
         admin = User(
             first_name="Crysta",
             last_name="Faerie",
@@ -119,603 +192,429 @@ def seed_database():
             password=get_password_hash("admin"),
             is_active=True,
         )
-        volunteer = User(
-            first_name="Pips",
-            last_name="Sprite",
-            login="PipsSprite",
+        admin.departments.extend([landes, lozere, creuse, vosges])
+
+        alice = User(
+            first_name="Alice",
+            last_name="Pinède",
+            login="AlicePinede",
             email="volunteer@example.com",
             role="volunteer",
             password=get_password_hash("volunteer"),
             is_active=True,
         )
+        alice.departments.append(landes)
 
-        admin.departments.append(paris.department)
-        volunteer.departments.append(paris.department)
-        users = [admin, volunteer]
+        bruno = User(
+            first_name="Bruno",
+            last_name="Cévennes",
+            login="BrunoCevennes",
+            email="bruno@example.com",
+            role="volunteer",
+            password=get_password_hash("volunteer"),
+            is_active=True,
+        )
+        bruno.departments.append(lozere)
+
+        chloe = User(
+            first_name="Chloé",
+            last_name="Vassivière",
+            login="ChloeVassiviere",
+            email="chloe@example.com",
+            role="volunteer",
+            password=get_password_hash("volunteer"),
+            is_active=True,
+        )
+        chloe.departments.extend([creuse, vosges])
+
+        david = User(
+            first_name="David",
+            last_name="Inactif",
+            login="DavidInactif",
+            email="david@example.com",
+            role="volunteer",
+            password=get_password_hash("volunteer"),
+            is_active=False,
+        )
+        david.departments.append(vosges)
+
+        users = [admin, alice, bruno, chloe, david]
         db.add_all(users)
         db.flush()
 
-        clear_cuts = [
-            ClearCutReport(
-                city=paris,
-                slope_area_hectare=15,
-                clear_cuts=[
-                    ClearCut(
-                        observation_start_date=datetime.now() - timedelta(days=10),
-                        observation_end_date=datetime.now() - timedelta(days=5),
-                        area_hectare=10,
-                        bdf_resinous_area_hectare=0.5,
-                        bdf_deciduous_area_hectare=0.5,
-                        bdf_mixed_area_hectare=0.5,
-                        bdf_poplar_area_hectare=0.5,
-                        ecological_zoning_area_hectare=5,
-                        location=from_shape(Point(2.380192, 48.878899), SRID),
-                        boundary=from_shape(
-                            MultiPolygon(
-                                [
-                                    (
-                                        [
-                                            (2.381136, 48.881707),
-                                            (2.379699, 48.880338),
-                                            (2.378497, 48.878687),
-                                            (2.378561, 48.877615),
-                                            (2.379162, 48.876825),
-                                            (2.381094, 48.876175),
-                                            (2.380879, 48.877573),
-                                            (2.382145, 48.8788),
-                                            (2.384012, 48.879407),
-                                            (2.383454, 48.880127),
-                                            (2.381694, 48.880042),
-                                            (2.381372, 48.880973),
-                                            (2.381136, 48.881707),
-                                        ],
-                                    )
-                                ]
-                            ),
-                            srid=SRID,
-                        ),
-                        ecological_zonings=[
-                            ClearCutEcologicalZoning(ecological_zoning_id=natura1.id),
-                            ClearCutEcologicalZoning(ecological_zoning_id=natura2.id),
-                        ],
-                    ),
-                    ClearCut(
-                        observation_start_date=datetime.now() - timedelta(days=10),
-                        observation_end_date=datetime.now() - timedelta(days=5),
-                        area_hectare=10,
-                        ecological_zoning_area_hectare=0.3,
-                        bdf_resinous_area_hectare=0.5,
-                        bdf_deciduous_area_hectare=0.5,
-                        bdf_mixed_area_hectare=0.5,
-                        bdf_poplar_area_hectare=0.5,
-                        location=from_shape(Point(1.380192, 48.878899), SRID),
-                        boundary=from_shape(
-                            MultiPolygon(
-                                [
-                                    (
-                                        [
-                                            (2.381136, 48.881707),
-                                            (2.379699, 48.880338),
-                                            (2.378497, 48.878687),
-                                            (2.378561, 48.877615),
-                                            (2.379162, 48.876825),
-                                            (2.381094, 48.876175),
-                                            (2.380879, 48.877573),
-                                            (2.382145, 48.8788),
-                                            (2.384012, 48.879407),
-                                            (2.383454, 48.880127),
-                                            (2.381694, 48.880042),
-                                            (2.381372, 48.880973),
-                                            (2.381136, 48.881707),
-                                        ],
-                                    )
-                                ]
-                            ),
-                            srid=SRID,
-                        ),
-                        ecological_zonings=[
-                            ClearCutEcologicalZoning(ecological_zoning_id=natura1.id),
-                        ],
-                    ),
-                ],
-                status="to_validate",
-                user=volunteer,
-            ),
-            ClearCutReport(
-                city=paris,
-                slope_area_hectare=10,
-                clear_cuts=[
-                    ClearCut(
-                        observation_start_date=datetime.now() - timedelta(days=5),
-                        observation_end_date=datetime.now() - timedelta(days=2),
-                        area_hectare=10,
-                        location=from_shape(Point(2.371101, 48.839001), SRID),
-                        boundary=from_shape(
-                            MultiPolygon(
-                                [
-                                    (
-                                        [
-                                            (2.375342, 48.832582),
-                                            (2.376072, 48.832286),
-                                            (2.376823, 48.831277),
-                                            (2.376898, 48.830677),
-                                            (2.376308, 48.83012),
-                                            (2.375921, 48.830134),
-                                            (2.375331, 48.830748),
-                                            (2.375514, 48.83175),
-                                            (2.375342, 48.832554),
-                                            (2.375342, 48.832582),
-                                        ],
-                                    )
-                                ]
-                            ),
-                            srid=SRID,
-                        ),
-                        ecological_zonings=[],
-                    ),
-                    ClearCut(
-                        observation_start_date=datetime.now() - timedelta(days=15),
-                        observation_end_date=datetime.now() - timedelta(days=2),
-                        area_hectare=13,
-                        location=from_shape(Point(2.381101, 48.839001), SRID),
-                        boundary=from_shape(
-                            MultiPolygon(
-                                [
-                                    (
-                                        [
-                                            (2.385342, 48.842582),
-                                            (2.386072, 48.842286),
-                                            (2.386823, 48.841277),
-                                            (2.386898, 48.840677),
-                                            (2.386308, 48.84012),
-                                            (2.385921, 48.840134),
-                                            (2.385331, 48.840748),
-                                            (2.385514, 48.84175),
-                                            (2.385342, 48.842554),
-                                            (2.385342, 48.842582),
-                                        ],
-                                    )
-                                ]
-                            ),
-                            srid=SRID,
-                        ),
-                        ecological_zonings=[],
-                    ),
-                ],
-                status="validated",
-                user=admin,
-            ),
-            ClearCutReport(
-                city=marseille,
-                slope_area_hectare=6.8,
-                clear_cuts=[
-                    ClearCut(
-                        observation_start_date=datetime.now() - timedelta(days=5),
-                        observation_end_date=datetime.now() - timedelta(days=2),
-                        area_hectare=10,
-                        location=from_shape(
-                            Point(5.3698, 43.2965), SRID
-                        ),  # Coordonnées approximatives de Marseille
-                        boundary=from_shape(
-                            MultiPolygon(
-                                [
-                                    (
-                                        [
-                                            (5.3708, 43.3005),
-                                            (5.3688, 43.2995),
-                                            (5.3678, 43.2975),
-                                            (5.3688, 43.2955),
-                                            (5.3708, 43.2945),
-                                            (5.3728, 43.2965),
-                                            (5.3708, 43.3005),
-                                        ],
-                                    )
-                                ]
-                            ),
-                            srid=SRID,
-                        ),
-                    )
-                ],
-                status="validated",
-                user=admin,
-            ),
-            ClearCutReport(
-                city=marseille,
-                slope_area_hectare=4.2,
-                clear_cuts=[
-                    ClearCut(
-                        observation_start_date=datetime.now() - timedelta(days=15),
-                        observation_end_date=datetime.now() - timedelta(days=9),
-                        area_hectare=10,
-                        location=from_shape(
-                            Point(5.4008, 43.2865), SRID
-                        ),  # Autour de Marseille
-                        boundary=from_shape(
-                            MultiPolygon(
-                                [
-                                    (
-                                        [
-                                            (5.4018, 43.2905),
-                                            (5.3998, 43.2895),
-                                            (5.3988, 43.2875),
-                                            (5.3998, 43.2855),
-                                            (5.4018, 43.2845),
-                                            (5.4038, 43.2865),
-                                            (5.4018, 43.2905),
-                                        ],
-                                    )
-                                ]
-                            ),
-                            srid=SRID,
-                        ),
-                    )
-                ],
-                status="validated",
-                user=admin,
-            ),
-            ClearCutReport(
-                city=marseille,
-                slope_area_hectare=5.7,
-                clear_cuts=[
-                    ClearCut(
-                        observation_start_date=datetime.now() - timedelta(days=10),
-                        observation_end_date=datetime.now() - timedelta(days=9),
-                        area_hectare=10,
-                        location=from_shape(
-                            Point(5.3508, 43.3165), SRID
-                        ),  # Autour de Marseille
-                        boundary=from_shape(
-                            MultiPolygon(
-                                [
-                                    (
-                                        [
-                                            (5.3518, 43.3205),
-                                            (5.3498, 43.3195),
-                                            (5.3488, 43.3175),
-                                            (5.3498, 43.3155),
-                                            (5.3518, 43.3145),
-                                            (5.3538, 43.3165),
-                                            (5.3518, 43.3205),
-                                        ],
-                                    )
-                                ]
-                            ),
-                            srid=SRID,
-                        ),
-                    )
-                ],
-                status="to_validate",
-                user=volunteer,
-            ),
-            ClearCutReport(
-                city=marseille,
-                clear_cuts=[
-                    ClearCut(
-                        observation_start_date=datetime.now() - timedelta(days=30),
-                        observation_end_date=datetime.now() - timedelta(days=9),
-                        area_hectare=10,
-                        location=from_shape(
-                            Point(5.3808, 43.2765), SRID
-                        ),  # Autour de Marseille
-                        boundary=from_shape(
-                            MultiPolygon(
-                                [
-                                    (
-                                        [
-                                            (5.3818, 43.2805),
-                                            (5.3798, 43.2795),
-                                            (5.3788, 43.2775),
-                                            (5.3798, 43.2755),
-                                            (5.3818, 43.2745),
-                                            (5.3838, 43.2765),
-                                            (5.3818, 43.2805),
-                                        ],
-                                    )
-                                ]
-                            ),
-                            srid=SRID,
-                        ),
-                    )
-                ],
-                slope_area_hectare=8.1,
-                status="validated",
-                user=admin,
-            ),
-            ClearCutReport(
-                city=marseille,
-                clear_cuts=[
-                    ClearCut(
-                        observation_start_date=datetime.now() - timedelta(days=2),
-                        observation_end_date=datetime.now() - timedelta(days=1),
-                        area_hectare=10,
-                        location=from_shape(
-                            Point(5.3908, 43.2665), SRID
-                        ),  # Autour de Marseille
-                        boundary=from_shape(
-                            MultiPolygon(
-                                [
-                                    (
-                                        [
-                                            (5.3918, 43.2705),
-                                            (5.3898, 43.2695),
-                                            (5.3888, 43.2675),
-                                            (5.3898, 43.2655),
-                                            (5.3918, 43.2645),
-                                            (5.3938, 43.2665),
-                                            (5.3918, 43.2705),
-                                        ],
-                                    )
-                                ]
-                            ),
-                            srid=SRID,
-                        ),
-                    )
-                ],
-                slope_area_hectare=3.9,
-                status="to_validate",
-                user=volunteer,
-            ),
-        ]
+        # --- Reports -----------------------------------------------------------
+        # The set below covers every status, every forest profile (incl. unknown),
+        # mono- and multi-cut reports, rule edge cases (area/slope/zoning above and
+        # below thresholds), an unassigned report with a pending assignment request,
+        # and a wide spread of cut dates (to exercise the date sort).
 
-        # --- Extra fixtures: cover every status and every forest profile ---
-        # Coordinates are picked away from the originals to avoid overlapping polygons.
-        extra_reports = [
-            # in_progress — admin took the file, large resineux around Marseille
-            ClearCutReport(
-                city=marseille,
-                slope_area_hectare=12,
-                status="in_progress",
-                user=admin,
-                clear_cuts=[
-                    make_clear_cut(
-                        5.43,
-                        43.30,
-                        area_hectare=15,
-                        forest_type="resinous",
-                        days_ago_start=20,
-                        days_ago_end=15,
-                    ),
-                ],
-            ),
-            # in_progress — volunteer is filling the form for a feuillus cut
-            ClearCutReport(
-                city=paris,
-                slope_area_hectare=3,
-                status="in_progress",
-                user=volunteer,
-                clear_cuts=[
-                    make_clear_cut(
-                        2.42,
-                        48.88,
-                        area_hectare=8,
-                        forest_type="deciduous",
-                        days_ago_start=18,
-                        days_ago_end=12,
-                    ),
-                ],
-            ),
-            # waiting_for_validation — mixed forest submitted by a volunteer
-            ClearCutReport(
-                city=marseille,
-                slope_area_hectare=7,
-                status="waiting_for_validation",
-                user=volunteer,
-                clear_cuts=[
-                    make_clear_cut(
-                        5.33,
-                        43.30,
-                        area_hectare=12,
-                        forest_type="mixed",
-                        days_ago_start=25,
-                        days_ago_end=20,
-                    ),
-                ],
-            ),
-            # waiting_for_validation — large peupleraie awaiting admin review
-            ClearCutReport(
-                city=marseille,
-                slope_area_hectare=2,
-                status="waiting_for_validation",
-                user=volunteer,
-                clear_cuts=[
-                    make_clear_cut(
-                        5.45,
-                        43.28,
-                        area_hectare=20,
-                        forest_type="poplar",
-                        days_ago_start=30,
-                        days_ago_end=25,
-                    ),
-                ],
-            ),
-            # legal_validated — coupe in a Natura2000 zone, large resineux
-            ClearCutReport(
-                city=marseille,
-                slope_area_hectare=15,
-                status="legal_validated",
-                user=admin,
-                clear_cuts=[
-                    make_clear_cut(
-                        5.31,
-                        43.28,
-                        area_hectare=25,
-                        forest_type="resinous",
-                        days_ago_start=60,
-                        days_ago_end=50,
-                        ecological_zoning_area=8,
-                        ecological_zonings=[natura1],
-                    ),
-                ],
-            ),
-            # legal_validated — mixed forest intersecting two protected zones
-            ClearCutReport(
-                city=paris,
-                slope_area_hectare=20,
-                status="legal_validated",
-                user=admin,
-                clear_cuts=[
-                    make_clear_cut(
-                        2.34,
-                        48.85,
-                        area_hectare=18,
-                        forest_type="mixed",
-                        days_ago_start=45,
-                        days_ago_end=40,
-                        ecological_zoning_area=10,
-                        ecological_zonings=[natura1, natura2],
-                    ),
-                ],
-            ),
-            # final_validated — small feuillus, nothing to pursue
-            ClearCutReport(
-                city=marseille,
-                slope_area_hectare=4,
-                status="final_validated",
-                user=admin,
-                clear_cuts=[
-                    make_clear_cut(
-                        5.33,
-                        43.32,
-                        area_hectare=6,
-                        forest_type="deciduous",
-                        days_ago_start=90,
-                        days_ago_end=85,
-                    ),
-                ],
-            ),
-            # final_validated — small resineux, low slope, no thresholds hit
-            ClearCutReport(
-                city=paris,
-                slope_area_hectare=1,
-                status="final_validated",
-                user=admin,
-                clear_cuts=[
-                    make_clear_cut(
-                        2.42,
-                        48.85,
-                        area_hectare=4,
-                        forest_type="resinous",
-                        days_ago_start=80,
-                        days_ago_end=75,
-                    ),
-                ],
-            ),
-            # rejected — small peupleraie, declared not relevant
-            ClearCutReport(
-                city=marseille,
-                slope_area_hectare=1,
-                status="rejected",
-                user=admin,
-                clear_cuts=[
-                    make_clear_cut(
-                        5.45,
-                        43.32,
-                        area_hectare=3,
-                        forest_type="poplar",
-                        days_ago_start=120,
-                        days_ago_end=115,
-                    ),
-                ],
-            ),
-            # rejected — feuillus, false positive from the satellite pipeline
-            ClearCutReport(
-                city=paris,
-                slope_area_hectare=2,
-                status="rejected",
-                user=admin,
-                clear_cuts=[
-                    make_clear_cut(
-                        2.42,
-                        48.84,
-                        area_hectare=5,
-                        forest_type="deciduous",
-                        days_ago_start=100,
-                        days_ago_end=95,
-                    ),
-                ],
-            ),
-            # to_validate — unassigned, the volunteer has requested the assignment
-            ClearCutReport(
-                city=marseille,
-                slope_area_hectare=5,
-                status="to_validate",
-                user=None,
-                assignment_requested_by=volunteer,
-                clear_cuts=[
-                    make_clear_cut(
-                        5.45,
-                        43.26,
-                        area_hectare=7,
-                        forest_type="mixed",
-                        days_ago_start=3,
-                        days_ago_end=1,
-                    ),
-                ],
-            ),
+        # Landes (40) — pinède résineuse, faible pente
+        r_sabres = ClearCutReport(
+            city=cities["sabres"],
+            slope_area_hectare=1.5,  # below slope threshold
+            status="to_validate",
+            user=alice,
+            clear_cuts=[
+                cut("sabres", area=12, forest="resinous", days_start=8, days_end=3),
+            ],
+        )
+        r_labouheyre = ClearCutReport(
+            city=cities["labouheyre"],
+            slope_area_hectare=1.0,
+            status="in_progress",
+            user=alice,
+            clear_cuts=[  # multi-cut, total 13 ha => area rule
+                cut("labouheyre", area=7, forest="resinous", days_start=20, days_end=10),
+                cut(
+                    "labouheyre",
+                    area=6,
+                    forest="resinous",
+                    days_start=20,
+                    days_end=10,
+                    dx=0.012,
+                ),
+            ],
+        )
+        r_morcenx = ClearCutReport(
+            city=cities["morcenx"],
+            slope_area_hectare=0.5,
+            status="waiting_for_validation",
+            user=alice,
+            clear_cuts=[
+                cut("morcenx", area=22, forest="poplar", days_start=30, days_end=25),
+            ],
+        )
+
+        # Lozère (48) — forêt mixte, forte pente, Natura 2000 Mont Lozère
+        r_mende = ClearCutReport(
+            city=cities["mende"],
+            slope_area_hectare=14,  # slope rule
+            status="legal_validated",
+            user=admin,
+            clear_cuts=[
+                cut(
+                    "mende",
+                    area=18,
+                    forest="mixed",
+                    days_start=60,
+                    days_end=50,
+                    eco_area=9,
+                    zonings=[zonings["lozere"]],
+                ),
+            ],
+        )
+        r_montvert = ClearCutReport(
+            city=cities["pont_de_montvert"],
+            slope_area_hectare=8,
+            status="validated",
+            user=bruno,
+            clear_cuts=[  # multi-cut, one inside the protected zone
+                cut(
+                    "pont_de_montvert",
+                    area=9,  # below area threshold on its own
+                    forest="mixed",
+                    days_start=45,
+                    days_end=30,
+                    eco_area=6,
+                    zonings=[zonings["lozere"]],
+                ),
+                cut(
+                    "pont_de_montvert",
+                    area=4,
+                    forest="mixed",
+                    days_start=45,
+                    days_end=30,
+                    dx=0.012,
+                ),
+            ],
+        )
+        r_mende_request = ClearCutReport(
+            city=cities["mende"],
+            slope_area_hectare=3,
+            status="to_validate",
+            user=None,  # unassigned, awaiting admin approval
+            assignment_requested_by=bruno,
+            clear_cuts=[
+                cut(
+                    "mende",
+                    area=8,
+                    forest="mixed",
+                    days_start=5,
+                    days_end=1,
+                    eco_area=2,
+                    zonings=[zonings["lozere"]],
+                    dx=0.02,
+                    dy=0.015,
+                ),
+            ],
+        )
+
+        # Creuse (23) — feuillus
+        r_aubusson = ClearCutReport(
+            city=cities["aubusson"],
+            slope_area_hectare=1.2,  # below threshold
+            status="final_validated",
+            user=chloe,
+            clear_cuts=[  # small, low slope, no zoning => no rule matched (clean case)
+                cut("aubusson", area=6, forest="deciduous", days_start=90, days_end=85),
+            ],
+        )
+        r_aubusson_unknown = ClearCutReport(
+            city=cities["aubusson"],
+            slope_area_hectare=2.5,
+            status="to_validate",
+            user=chloe,
+            clear_cuts=[  # unknown forest type => bdf areas are NULL
+                cut(
+                    "aubusson",
+                    area=11,
+                    forest="unknown",
+                    days_start=7,
+                    days_end=2,
+                    dx=0.02,
+                    dy=0.015,
+                ),
+            ],
+        )
+        r_royere = ClearCutReport(
+            city=cities["royere"],
+            slope_area_hectare=2.0,
+            status="rejected",
+            user=admin,
+            clear_cuts=[  # false positive from the satellite pipeline
+                cut("royere", area=5, forest="deciduous", days_start=100, days_end=95),
+            ],
+        )
+
+        # Vosges (88) — mixte/résineux, forte pente, Natura 2000 massif vosgien
+        r_gerardmer = ClearCutReport(
+            city=cities["gerardmer"],
+            slope_area_hectare=16,
+            status="waiting_for_validation",
+            user=chloe,
+            clear_cuts=[
+                cut(
+                    "gerardmer",
+                    area=25,
+                    forest="resinous",
+                    days_start=25,
+                    days_end=20,
+                    eco_area=10,
+                    zonings=[zonings["vosges"]],
+                ),
+            ],
+        )
+        r_labresse = ClearCutReport(
+            city=cities["la_bresse"],
+            slope_area_hectare=20,
+            status="legal_validated",
+            user=admin,
+            clear_cuts=[  # multi-cut, large, in protected zone
+                cut(
+                    "la_bresse",
+                    area=15,
+                    forest="resinous",
+                    days_start=70,
+                    days_end=60,
+                    eco_area=8,
+                    zonings=[zonings["vosges"]],
+                ),
+                cut(
+                    "la_bresse",
+                    area=10,
+                    forest="mixed",
+                    days_start=70,
+                    days_end=60,
+                    dx=0.014,
+                ),
+            ],
+        )
+        r_gerardmer_progress = ClearCutReport(
+            city=cities["gerardmer"],
+            slope_area_hectare=5,
+            status="in_progress",
+            user=chloe,
+            clear_cuts=[
+                cut(
+                    "gerardmer",
+                    area=12,
+                    forest="mixed",
+                    days_start=18,
+                    days_end=12,
+                    dx=0.02,
+                    dy=0.015,
+                ),
+            ],
+        )
+        r_labresse_small = ClearCutReport(
+            city=cities["la_bresse"],
+            slope_area_hectare=1,
+            status="final_validated",
+            user=admin,
+            clear_cuts=[  # small, below every threshold
+                cut(
+                    "la_bresse",
+                    area=4,
+                    forest="resinous",
+                    days_start=80,
+                    days_end=75,
+                    dx=0.02,
+                    dy=0.015,
+                ),
+            ],
+        )
+        r_royere_rejected = ClearCutReport(
+            city=cities["royere"],
+            slope_area_hectare=1,
+            status="rejected",
+            user=admin,
+            clear_cuts=[
+                cut(
+                    "royere",
+                    area=3,
+                    forest="poplar",
+                    days_start=120,
+                    days_end=115,
+                    dx=0.02,
+                    dy=0.015,
+                ),
+            ],
+        )
+
+        reports = [
+            r_sabres,
+            r_labouheyre,
+            r_morcenx,
+            r_mende,
+            r_montvert,
+            r_mende_request,
+            r_aubusson,
+            r_aubusson_unknown,
+            r_royere,
+            r_gerardmer,
+            r_labresse,
+            r_gerardmer_progress,
+            r_labresse_small,
+            r_royere_rejected,
         ]
-        clear_cuts.extend(extra_reports)
-        db.add_all(clear_cuts)
+        db.add_all(reports)
+
+        # --- Favorites ---------------------------------------------------------
+        alice.favorites.append(r_sabres)
+        bruno.favorites.append(r_montvert)
+        admin.favorites.extend([r_labresse, r_mende])
 
         db.flush()
 
-        reportform = ClearCutForm(
-            report_id=clear_cuts[0].id,
-            editor_id=admin.id,
-            inspection_date=datetime.now(),
-            weather="Sunny",
-            forest="Dense pine forest",
-            has_remaining_trees=True,
-            trees_species="Pinus sylvestris",
-            planting_images=["planting_image_1.jpg", "planting_image_2.jpg"],
-            has_construction_panel=False,
-            construction_panel_images=[
-                "construction_panel_image_1.jpg",
-                "construction_panel_image_2.jpg",
-            ],
-            wetland="Yes",
-            destruction_clues="None",
-            soil_state="Healthy",
-            clear_cut_images=["clear_cut_image_1.jpg", "clear_cut_image_2.jpg"],
-            tree_trunks_images=["tree_trunks_image_1.jpg", "tree_trunks_image_2.jpg"],
-            soil_state_images=["soil_state_image_1.jpg", "soil_state_image_2.jpg"],
-            access_road_images=["access_road_image_1.jpg", "access_road_image_2.jpg"],
-            # Ecological informations
-            has_other_ecological_zone=False,
-            other_ecological_zone_type="N/A",
-            has_nearby_ecological_zone=True,
-            nearby_ecological_zone_type="Wetland",
-            protected_species="None",
-            protected_habitats="None",
-            has_ddt_request=False,
-            ddt_request_owner="N/A",
-            # Stakeholders
-            company="EcoTree",
-            subcontractor="TreeServices",
-            landlord="John Doe",
-            # Reglementation
-            is_pefc_fsc_certified=True,
-            is_over_20_ha=False,
-            is_psg_required_plot=True,
-            # Legal strategy
-            relevant_for_pefc_complaint=False,
-            relevant_for_rediii_complaint=False,
-            relevant_for_ofb_complaint=False,
-            relevant_for_alert_cnpf_ddt_srgs=False,
-            relevant_for_alert_cnpf_ddt_psg_thresholds=False,
-            relevant_for_psg_request=False,
-            request_engaged="None",
-            # Miscellaneous
-            other="No additional information",
+        # --- Forms -------------------------------------------------------------
+        # Two fully-filled forms, one partial draft. Image fields point to real
+        # files copied into each report's upload folder so they actually render.
+        full_forms = [
+            ClearCutForm(
+                report_id=r_mende.id,
+                editor_id=admin.id,
+                inspection_date=datetime.now() - timedelta(days=48),
+                weather="Ensoleillé",
+                forest="Hêtraie-sapinière de montagne",
+                has_remaining_trees=False,
+                trees_species="Fagus sylvatica, Abies alba",
+                planting_images=[seed_report_image(r_mende.id, "planting")],
+                has_construction_panel=True,
+                construction_panel_images=[seed_report_image(r_mende.id, "panel")],
+                wetland="Non",
+                destruction_clues="Sol fortement tassé, ornières profondes",
+                soil_state="Dégradé",
+                clear_cut_images=[seed_report_image(r_mende.id, "clearcut")],
+                tree_trunks_images=[seed_report_image(r_mende.id, "trunks")],
+                soil_state_images=[seed_report_image(r_mende.id, "soil")],
+                access_road_images=[seed_report_image(r_mende.id, "road")],
+                has_other_ecological_zone=True,
+                other_ecological_zone_type="ZNIEFF",
+                has_nearby_ecological_zone=True,
+                nearby_ecological_zone_type="Natura 2000 (Mont Lozère)",
+                protected_species="Grand tétras",
+                protected_habitats="Tourbières de montagne",
+                has_ddt_request=True,
+                ddt_request_owner="DDT 48",
+                company="Scierie du Gévaudan",
+                subcontractor="Travaux Forestiers Lozère",
+                landlord="Groupement Forestier du Mont Lozère",
+                is_pefc_fsc_certified=False,
+                is_over_20_ha=False,
+                is_psg_required_plot=True,
+                relevant_for_pefc_complaint=False,
+                relevant_for_rediii_complaint=True,
+                relevant_for_ofb_complaint=True,
+                relevant_for_alert_cnpf_ddt_srgs=True,
+                relevant_for_alert_cnpf_ddt_psg_thresholds=True,
+                relevant_for_psg_request=True,
+                request_engaged="Signalement OFB en cours",
+                other="Coupe en zone Natura 2000, forte pente, à suivre en priorité",
+            ),
+            ClearCutForm(
+                report_id=r_labresse.id,
+                editor_id=admin.id,
+                inspection_date=datetime.now() - timedelta(days=58),
+                weather="Couvert",
+                forest="Pessière (épicéa)",
+                has_remaining_trees=True,
+                trees_species="Picea abies",
+                planting_images=[seed_report_image(r_labresse.id, "planting")],
+                has_construction_panel=False,
+                construction_panel_images=[],
+                wetland="Non",
+                destruction_clues="Aucun indice particulier",
+                soil_state="Correct",
+                clear_cut_images=[seed_report_image(r_labresse.id, "clearcut")],
+                tree_trunks_images=[seed_report_image(r_labresse.id, "trunks")],
+                soil_state_images=[],
+                access_road_images=[seed_report_image(r_labresse.id, "road")],
+                has_other_ecological_zone=False,
+                other_ecological_zone_type=None,
+                has_nearby_ecological_zone=True,
+                nearby_ecological_zone_type="Massif vosgien",
+                protected_species="Aucune observée",
+                protected_habitats="Aucun",
+                has_ddt_request=False,
+                ddt_request_owner=None,
+                company="Exploitation Forestière des Hautes-Vosges",
+                subcontractor=None,
+                landlord="Commune de La Bresse",
+                is_pefc_fsc_certified=True,
+                is_over_20_ha=True,
+                is_psg_required_plot=True,
+                relevant_for_pefc_complaint=True,
+                relevant_for_rediii_complaint=False,
+                relevant_for_ofb_complaint=False,
+                relevant_for_alert_cnpf_ddt_srgs=False,
+                relevant_for_alert_cnpf_ddt_psg_thresholds=True,
+                relevant_for_psg_request=False,
+                request_engaged="Plainte PEFC déposée",
+                other="Coupe > 20 ha en zone protégée",
+            ),
+        ]
+
+        # Partial draft (volunteer started filling the form while in progress)
+        draft_form = ClearCutForm(
+            report_id=r_labouheyre.id,
+            editor_id=alice.id,
+            inspection_date=datetime.now() - timedelta(days=9),
+            weather="Ensoleillé",
+            forest="Pin maritime",
+            has_remaining_trees=False,
+            trees_species="Pinus pinaster",
+            clear_cut_images=[seed_report_image(r_labouheyre.id, "clearcut")],
         )
 
-        db.add(reportform)
+        db.add_all([*full_forms, draft_form])
 
         sync_clear_cuts_reports(db)
 
         db.commit()
 
         print(f"Added {len(users)} users to the database")
-        print(f"Added {len(clear_cuts)} clear cut reports to the database")
+        print(f"Added {len(reports)} clear cut reports to the database")
+        print(f"Added {len(full_forms) + 1} clear cut forms to the database")
         print("Database finished seeding!")
 
     except Exception as e:

--- a/backend/test/web_api/test_clear_cut_forms.py
+++ b/backend/test/web_api/test_clear_cut_forms.py
@@ -46,16 +46,13 @@ def test_create_version_success(client: TestClient, db: Session):
         "soilStateImages": ["string"],
         "accessRoadImages": ["string"],
     }
-    response = client.get(
-        "/api/v1/clear-cuts-reports/1/forms",
-    ).json()
-
+    # Report 1 has no form yet in the seed, so the first version is created
+    # without an Etag (the optimistic-lock check is skipped when no form exists).
     response = client.post(
         "/api/v1/clear-cuts-reports/1/forms",
         json=report_data,
         headers={
             "Authorization": f"Bearer {token}",
-            "Etag": response["content"][0]["etag"],
         },
     )
 
@@ -148,15 +145,13 @@ def test_form_submission_does_not_auto_update_report_status(
         "weather": "Test Weather",
         "workSignVisible": False,
     }
-    response = client.get(
-        "/api/v1/clear-cuts-reports/1/forms",
-    ).json()
+    # Report 1 has no form yet in the seed, so the first version is created
+    # without an Etag (the optimistic-lock check is skipped when no form exists).
     response = client.post(
         "/api/v1/clear-cuts-reports/1/forms",
         json=form_data,
         headers={
             "Authorization": f"Bearer {token}",
-            "Etag": response["content"][0]["etag"],
         },
     )
     assert response.status_code == status.HTTP_201_CREATED

--- a/backend/test/web_api/test_clear_cuts_map.py
+++ b/backend/test/web_api/test_clear_cuts_map.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from test.common.clear_cut import new_clear_cut_report
 
 
@@ -13,3 +15,25 @@ def test_get_clearcuts_map(client, db):
     data = response.json()
     assert data["previews"] is not None
     assert data["points"] is not None
+
+
+def test_get_clearcuts_map_sorted_by_first_cut_date(client, db):
+    # status "validated" so the reports pass the relevance filter;
+    # extreme dates so ordering is deterministic whatever the seeded data
+    oldest = new_clear_cut_report(status="validated")
+    oldest.first_cut_date = datetime(1900, 1, 1)
+    oldest.clear_cuts[0].observation_start_date = datetime(1900, 1, 1)
+    newest = new_clear_cut_report(status="validated")
+    newest.first_cut_date = datetime(2999, 1, 1)
+    newest.clear_cuts[0].observation_start_date = datetime(2999, 1, 1)
+    db.add_all([oldest, newest])
+    db.commit()
+    oldest_id, newest_id = str(oldest.id), str(newest.id)
+
+    desc = client.get("/api/v1/clear-cuts-map?sortBy=first_cut_date&sortOrder=desc")
+    assert desc.status_code == 200
+    assert desc.json()["previews"][0]["id"] == newest_id
+
+    asc = client.get("/api/v1/clear-cuts-map?sortBy=first_cut_date&sortOrder=asc")
+    assert asc.status_code == 200
+    assert asc.json()["previews"][0]["id"] == oldest_id

--- a/backend/test/web_api/test_user.py
+++ b/backend/test/web_api/test_user.py
@@ -109,8 +109,9 @@ def test_get_users(client, db):
     assert response.status_code == 200
 
     data = response.json()
-    assert len(data["content"]) == 4
-    assert data["content"][3]["id"] == str(user.id)
+    # 5 seeded users + the admin created for the token + the "ABC" user above.
+    assert len(data["content"]) == 7
+    assert data["content"][-1]["id"] == str(user.id)
 
 
 def test_login_user(client, db):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,11 @@ services:
       POSTGRES_USER: devuser
       POSTGRES_PASSWORD: devuser
       DATABASES: local,test
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U devuser -d local"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
   pgadmin:
     image: dpage/pgadmin4
     container_name: pgadmin4_container
@@ -49,7 +54,8 @@ services:
       DATABASE_URL: postgresql://devuser:devuser@db:5432/local
       ALLOWED_ORIGINS: http://localhost:5173,http://localhost:8081
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 
   frontend:
       build:

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -1,0 +1,64 @@
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+import type * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Sheet({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+	return <DialogPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+	return <DialogPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+	return <DialogPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+/**
+ * Minimal bottom sheet built on the Radix dialog primitive. Slides up from the
+ * bottom edge with a drag-handle affordance — used for mobile filter panels
+ * where a dropdown would be too cramped.
+ */
+function SheetContent({
+	className,
+	children,
+	title,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & { title: string }) {
+	return (
+		<DialogPrimitive.Portal>
+			<DialogPrimitive.Overlay className="fixed inset-0 z-[200] bg-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+			<DialogPrimitive.Content
+				data-slot="sheet-content"
+				className={cn(
+					"fixed inset-x-0 bottom-0 z-[200] flex max-h-[85dvh] flex-col rounded-t-2xl border-t bg-background p-4 pb-[calc(1rem+env(safe-area-inset-bottom))] shadow-lg",
+					"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+					className
+				)}
+				{...props}
+			>
+				<div className="mx-auto mb-3 h-1.5 w-12 shrink-0 rounded-full bg-zinc-300" />
+				<div className="mb-2 flex shrink-0 items-center justify-between">
+					<DialogPrimitive.Title className="text-base font-semibold">
+						{title}
+					</DialogPrimitive.Title>
+					<DialogPrimitive.Close className="rounded-md p-1 text-zinc-500 hover:bg-zinc-100">
+						<XIcon className="size-5" />
+						<span className="sr-only">Fermer</span>
+					</DialogPrimitive.Close>
+				</div>
+				{children}
+			</DialogPrimitive.Content>
+		</DialogPrimitive.Portal>
+	)
+}
+
+export { Sheet, SheetClose, SheetContent, SheetTrigger }

--- a/frontend/src/features/admin/components/action-required/ActionRequiredTab.tsx
+++ b/frontend/src/features/admin/components/action-required/ActionRequiredTab.tsx
@@ -1,8 +1,13 @@
 import { useNavigate } from "@tanstack/react-router"
-import { Check, ChevronRight, FileWarning, X } from "lucide-react"
+import { Check, ChevronRight, FileWarning, UserIcon, X } from "lucide-react"
 import { useEffect } from "react"
 
 import { Button } from "@/components/ui/button"
+import { UpdateUserDialog } from "@/features/admin/components/users-list/UpdateUserDialog"
+import {
+	selectPendingUsers,
+	useGetUsers
+} from "@/features/admin/store/users.slice"
 import {
 	approveValidationThunk,
 	getAdminActionRequiredReportsThunk,
@@ -10,11 +15,8 @@ import {
 	selectAdminActionRequiredReports,
 	selectAssignation
 } from "@/features/clear-cut/store/clear-cuts-slice"
-import { UpdateUserDialog } from "@/features/admin/components/users-list/UpdateUserDialog"
-import { selectPendingUsers, useGetUsers } from "@/features/admin/store/users.slice"
 import { TimeProgress } from "@/shared/components/TimeProgress"
 import { useAppDispatch, useAppSelector } from "@/shared/hooks/store"
-import { UserIcon } from "lucide-react"
 
 export function ActionRequiredTab() {
 	const dispatch = useAppDispatch()
@@ -67,8 +69,12 @@ export function ActionRequiredTab() {
 	}
 
 	const reports = reportsState.value?.content ?? []
-	const validationRequests = reports.filter((r) => r.status === "waiting_for_validation")
-	const otherActions = reports.filter((r) => r.status !== "waiting_for_validation")
+	const validationRequests = reports.filter(
+		(r) => r.status === "waiting_for_validation"
+	)
+	const otherActions = reports.filter(
+		(r) => r.status !== "waiting_for_validation"
+	)
 
 	return (
 		<div className="flex flex-col w-full h-full p-2 overflow-y-auto bg-white">
@@ -76,7 +82,8 @@ export function ActionRequiredTab() {
 				Coupes nécessitant une action
 			</h2>
 			<p className="text-neutral-600 mb-6 font-light">
-				Signalements de nouvelles coupes à valider ou demandes d'attribution en attente.
+				Signalements de nouvelles coupes à valider ou demandes d'attribution en
+				attente.
 			</p>
 
 			{/* Validation requests from volunteers */}
@@ -98,7 +105,8 @@ export function ActionRequiredTab() {
 											{report.city || "Ville Inconnue"}
 										</h3>
 										<p className="text-xs text-neutral-500">
-											Dép. {report.department.code} · {report.totalAreaHectare?.toFixed(1) || 0} ha
+											Dép. {report.department.code} ·{" "}
+											{report.totalAreaHectare?.toFixed(1) || 0} ha
 										</p>
 									</div>
 									<div className="bg-orange-400 text-white text-[10px] px-2 py-0.5 rounded font-bold uppercase ml-2 shrink-0">
@@ -107,11 +115,15 @@ export function ActionRequiredTab() {
 								</div>
 								{report.affectedUser && (
 									<p className="text-xs text-neutral-600">
-										Bénévole : <span className="font-medium">{report.affectedUser.login}</span>
+										Bénévole :{" "}
+										<span className="font-medium">
+											{report.affectedUser.login}
+										</span>
 									</p>
 								)}
 								<p className="text-xs text-neutral-500">
-									Mis à jour le {new Date(report.updatedAt).toLocaleDateString("fr-FR")}
+									Mis à jour le{" "}
+									{new Date(report.updatedAt).toLocaleDateString("fr-FR")}
 								</p>
 								<div className="flex gap-2 mt-1">
 									<Button
@@ -126,7 +138,7 @@ export function ActionRequiredTab() {
 								<div className="flex gap-2">
 									<Button
 										size="sm"
-										className="flex-1 bg-green-600 hover:bg-green-700 text-white font-semibold min-h-[44px]"
+										className="flex-1 font-semibold min-h-[44px]"
 										disabled={assignation.status === "loading"}
 										onClick={(e) => handleApproveValidation(e, report.id)}
 									>
@@ -176,7 +188,8 @@ export function ActionRequiredTab() {
 								</div>
 								<div className="flex items-center justify-between pt-2 border-t border-amber-100/50">
 									<span className="text-xs text-neutral-600 italic">
-										Inscrit le {new Date(user.createdAt).toLocaleDateString("fr-FR")}
+										Inscrit le{" "}
+										{new Date(user.createdAt).toLocaleDateString("fr-FR")}
 									</span>
 									<UpdateUserDialog {...user} />
 								</div>
@@ -199,11 +212,12 @@ export function ActionRequiredTab() {
 								className="bg-white p-5 rounded-xl shadow-sm border border-neutral-200 hover:shadow-md hover:border-primary/30 transition-all cursor-pointer flex flex-col group relative overflow-hidden"
 								onClick={() => navigate({ to: `/clear-cuts/${report.id}` })}
 							>
-								{report.status === "to_validate" && !report.assignmentRequestedById && (
-									<div className="absolute top-0 right-0 bg-red-500 text-white text-[10px] px-2 py-1 rounded-bl-lg font-bold uppercase tracking-wider">
-										Nouvelle Zone
-									</div>
-								)}
+								{report.status === "to_validate" &&
+									!report.assignmentRequestedById && (
+										<div className="absolute top-0 right-0 bg-red-500 text-white text-[10px] px-2 py-1 rounded-bl-lg font-bold uppercase tracking-wider">
+											Nouvelle Zone
+										</div>
+									)}
 								{report.assignmentRequestedById && (
 									<div className="absolute top-0 right-0 bg-amber-500 text-white text-[10px] px-2 py-1 rounded-bl-lg font-bold uppercase tracking-wider">
 										Demande Attribution

--- a/frontend/src/features/clear-cut/components/MyCuts.tsx
+++ b/frontend/src/features/clear-cut/components/MyCuts.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "@tanstack/react-router"
-import { ChevronRight, Clock, FileWarning } from "lucide-react"
+import { ChevronRight, Clock, FileWarning, LogOut } from "lucide-react"
 import { useEffect } from "react"
 
 import { Button } from "@/components/ui/button"
@@ -8,7 +8,9 @@ import {
 	selectMyAssignedReports
 } from "@/features/clear-cut/store/clear-cuts-slice"
 import { useConnectedMe } from "@/features/user/store/me.slice"
+import { IconButton } from "@/shared/components/button/Button"
 import { TimeProgress } from "@/shared/components/TimeProgress"
+import { useLogout } from "@/shared/hooks/auth"
 import { useAppDispatch, useAppSelector } from "@/shared/hooks/store"
 
 export function MyCuts() {
@@ -16,6 +18,7 @@ export function MyCuts() {
 	const navigate = useNavigate()
 	const reportsState = useAppSelector(selectMyAssignedReports)
 	const me = useConnectedMe()
+	const handleLogout = useLogout()
 
 	useEffect(() => {
 		dispatch(getMyAssignedReportsThunk({ page: 0, size: 50 }))
@@ -48,9 +51,21 @@ export function MyCuts() {
 
 	return (
 		<div className="flex flex-col w-full h-full p-6 sm:p-10 overflow-y-auto bg-neutral-50">
-			<h1 className="text-3xl font-bold text-primary font-poppins mb-2">
-				Mes Coupes
-			</h1>
+			<div className="flex items-start justify-between gap-4 mb-2">
+				<h1 className="text-3xl font-bold text-primary font-poppins">
+					Mes Coupes
+				</h1>
+				<IconButton
+					variant="outline"
+					size="sm"
+					className="sm:hidden shrink-0"
+					onClick={handleLogout}
+					icon={<LogOut />}
+					position="start"
+				>
+					Déconnexion
+				</IconButton>
+			</div>
 			<p className="text-neutral-600 mb-8 font-light">
 				Retrouvez ici toutes les coupes rases qui vous ont été attribuées pour
 				vérification.
@@ -80,54 +95,56 @@ export function MyCuts() {
 							report.assignmentRequestedById === me.id &&
 							report.userId !== me.id
 						return (
-						<div
-							key={report.id}
-							className="bg-white p-5 rounded-xl shadow-sm border border-neutral-100 hover:shadow-md hover:border-primary/30 transition-all cursor-pointer flex flex-col group"
-							onClick={() => navigate({ to: `/clear-cuts/${report.id}` })}
-						>
-							<div className="flex justify-between items-start mb-3 gap-2">
-								<h3
-									className="font-semibold text-lg text-neutral-800 truncate"
-									title={report.city}
-								>
-									{report.city}
-								</h3>
-								<div className="bg-primary/10 text-primary text-xs px-2.5 py-1 rounded-full font-medium shrink-0">
-									{report.department.code}
+							<div
+								key={report.id}
+								className="bg-white p-5 rounded-xl shadow-sm border border-neutral-100 hover:shadow-md hover:border-primary/30 transition-all cursor-pointer flex flex-col group"
+								onClick={() => navigate({ to: `/clear-cuts/${report.id}` })}
+							>
+								<div className="flex justify-between items-start mb-3 gap-2">
+									<h3
+										className="font-semibold text-lg text-neutral-800 truncate"
+										title={report.city}
+									>
+										{report.city}
+									</h3>
+									<div className="bg-primary/10 text-primary text-xs px-2.5 py-1 rounded-full font-medium shrink-0">
+										{report.department.code}
+									</div>
+								</div>
+
+								{isPendingAssignment && (
+									<div className="mb-3 inline-flex items-center gap-1.5 self-start bg-amber-100 text-amber-800 text-xs px-2.5 py-1 rounded-full font-medium border border-amber-200">
+										<Clock className="h-3.5 w-3.5" />
+										En attente de validation de l'assignation
+									</div>
+								)}
+
+								<div className="space-y-1 mb-6 flex-grow">
+									<p className="text-sm text-neutral-600">
+										<span className="font-medium text-neutral-900">
+											Surface :
+										</span>{" "}
+										{report.totalAreaHectare.toFixed(1)} ha
+									</p>
+									<p className="text-sm text-neutral-600">
+										<span className="font-medium text-neutral-900">
+											Date approx. :
+										</span>{" "}
+										{new Date(report.lastCutDate).toLocaleDateString("fr-FR")}
+									</p>
+									<p className="text-sm text-neutral-600">
+										<span className="font-medium text-neutral-900">
+											Statut :
+										</span>{" "}
+										{report.status === "to_validate" ? "À valider" : "En cours"}
+									</p>
+								</div>
+
+								<div className="pt-4 border-t border-neutral-100 flex items-center justify-between text-sm font-medium text-primary group-hover:text-primary-dark transition-colors">
+									<span>Consulter le détail</span>
+									<ChevronRight className="h-4 w-4 transform group-hover:translate-x-1 transition-transform" />
 								</div>
 							</div>
-
-							{isPendingAssignment && (
-								<div className="mb-3 inline-flex items-center gap-1.5 self-start bg-amber-100 text-amber-800 text-xs px-2.5 py-1 rounded-full font-medium border border-amber-200">
-									<Clock className="h-3.5 w-3.5" />
-									En attente de validation de l'assignation
-								</div>
-							)}
-
-							<div className="space-y-1 mb-6 flex-grow">
-								<p className="text-sm text-neutral-600">
-									<span className="font-medium text-neutral-900">
-										Surface :
-									</span>{" "}
-									{report.totalAreaHectare.toFixed(1)} ha
-								</p>
-								<p className="text-sm text-neutral-600">
-									<span className="font-medium text-neutral-900">
-										Date approx. :
-									</span>{" "}
-									{new Date(report.lastCutDate).toLocaleDateString("fr-FR")}
-								</p>
-								<p className="text-sm text-neutral-600">
-									<span className="font-medium text-neutral-900">Statut :</span>{" "}
-									{report.status === "to_validate" ? "À valider" : "En cours"}
-								</p>
-							</div>
-
-							<div className="pt-4 border-t border-neutral-100 flex items-center justify-between text-sm font-medium text-primary group-hover:text-primary-dark transition-colors">
-								<span>Consulter le détail</span>
-								<ChevronRight className="h-4 w-4 transform group-hover:translate-x-1 transition-transform" />
-							</div>
-						</div>
 						)
 					})}
 				</div>

--- a/frontend/src/features/clear-cut/components/RuleBadge.tsx
+++ b/frontend/src/features/clear-cut/components/RuleBadge.tsx
@@ -1,4 +1,7 @@
+import { TriangleAlert } from "lucide-react"
+
 import { Badge } from "@/components/ui/badge"
+import { cn } from "@/lib/utils"
 import type { Rule } from "@/shared/store/referential/referential"
 
 function translateRule(rule: Rule) {
@@ -12,9 +15,18 @@ function translateRule(rule: Rule) {
 	}
 }
 
+// Rule badges flag *why a cut may be abusive* — they are risk indicators, not
+// success states, so they read as amber warnings rather than the brand green.
 export function RuleBadge(tag: Rule & { className?: string }) {
 	return (
-		<Badge className={tag.className} variant="default">
+		<Badge
+			variant="outline"
+			className={cn(
+				"gap-1 border-amber-300 bg-amber-50 text-amber-800",
+				tag.className
+			)}
+		>
+			<TriangleAlert className="size-3" aria-hidden />
 			{translateRule(tag)}
 		</Badge>
 	)

--- a/frontend/src/features/clear-cut/components/filters/AdvancedFilters.tsx
+++ b/frontend/src/features/clear-cut/components/filters/AdvancedFilters.tsx
@@ -2,14 +2,14 @@ import clsx from "clsx"
 import { type FC, type PropsWithChildren, useEffect } from "react"
 import { FormattedDate } from "react-intl"
 
+import { Button } from "@/components/ui/button"
 import { Slider } from "@/components/ui/slider"
 import { StatusWithLabel } from "@/features/clear-cut/components/StatusWithLabel"
-import { Button } from "@/components/ui/button"
 import {
 	commitFilters,
-	resetFilters,
 	filtersSlice,
 	getFiltersThunk,
+	resetFilters,
 	selectAreaRange,
 	selectAreas,
 	selectCutMonths,
@@ -33,6 +33,7 @@ import {
 
 interface Props {
 	className?: string
+	onClose?: () => void
 }
 const CUT_YEARS = {
 	label: "Années",
@@ -67,7 +68,7 @@ const FAVORITE = {
 	label: "Favoris"
 }
 
-export function AdvancedFilters({ className }: Props) {
+export function AdvancedFilters({ className, onClose }: Props) {
 	const dispatch = useAppDispatch()
 	const cutYears = useEnhancedItems({
 		items: useAppSelector(selectCutYears),
@@ -122,8 +123,8 @@ export function AdvancedFilters({ className }: Props) {
 			)
 	)
 	return (
-		<div className={clsx("flex flex-col gap-2 py-3", className)}>
-			<div className="flex gap-2">
+		<div className={clsx("flex flex-col gap-3 py-3", className)}>
+			<div className="flex flex-col sm:flex-row gap-2">
 				<FieldWrapper>
 					<label htmlFor={DEPARTMENTS.id}>{DEPARTMENTS.label}</label>
 					<ComboboxFilter
@@ -168,7 +169,7 @@ export function AdvancedFilters({ className }: Props) {
 					</div>
 				</div>
 			</div>
-			<div className="flex gap-2">
+			<div className="flex flex-col sm:flex-row gap-2">
 				<FieldWrapper>
 					<label htmlFor={AREA.id}>
 						{AREA.label} hectares{" "}
@@ -252,12 +253,19 @@ export function AdvancedFilters({ className }: Props) {
 				<Button variant="outline" onClick={() => dispatch(resetFilters())}>
 					Réinitialiser
 				</Button>
-				<Button onClick={() => dispatch(commitFilters())}>OK</Button>
+				<Button
+					onClick={() => {
+						dispatch(commitFilters())
+						onClose?.()
+					}}
+				>
+					OK
+				</Button>
 			</div>
 		</div>
 	)
 }
 
 const FieldWrapper: FC<PropsWithChildren> = ({ children }) => {
-	return <div className="flex w-1/2 flex-col gap-1"> {children}</div>
+	return <div className="flex w-full sm:w-1/2 flex-col gap-1"> {children}</div>
 }

--- a/frontend/src/features/clear-cut/components/form/AccordionHeader.tsx
+++ b/frontend/src/features/clear-cut/components/form/AccordionHeader.tsx
@@ -1,15 +1,10 @@
 import { FormattedNumber } from "react-intl"
 
+import { Button } from "@/components/ui/button"
 import type {
 	ClearCutFormInput,
 	ClearCutStatus
 } from "@/features/clear-cut/store/clear-cuts"
-import type { FormType } from "@/shared/form/types"
-import type { Rule } from "@/shared/store/referential/referential"
-
-import { RuleBadge } from "../RuleBadge"
-import { StatusWithLabel } from "../StatusWithLabel"
-
 import {
 	approveAssignmentThunk,
 	cancelAssignRequestThunk,
@@ -21,9 +16,13 @@ import {
 } from "@/features/clear-cut/store/clear-cuts-slice"
 import { selectFiltersRequest } from "@/features/clear-cut/store/filters.slice"
 import { useConnectedMe } from "@/features/user/store/me.slice"
-import { useAppDispatch, useAppSelector } from "@/shared/hooks/store"
-import { Button } from "@/components/ui/button"
 import { useToast } from "@/hooks/use-toast"
+import type { FormType } from "@/shared/form/types"
+import { useAppDispatch, useAppSelector } from "@/shared/hooks/store"
+import type { Rule } from "@/shared/store/referential/referential"
+
+import { RuleBadge } from "../RuleBadge"
+import { StatusWithLabel } from "../StatusWithLabel"
 
 export function AccordionHeader({
 	form,
@@ -44,9 +43,18 @@ export function AccordionHeader({
 	const reportId = form.getValues("report.id")
 	const reportUserId = form.getValues("report.userId")
 	const report = form.getValues("report") as any
-	const assignmentRequestedById = report?.assignmentRequestedById as string | null | undefined
-	const affectedUserLogin = report?.affectedUser?.login as string | null | undefined
-	const assignmentRequestedByLogin = report?.assignmentRequestedBy?.login as string | null | undefined
+	const assignmentRequestedById = report?.assignmentRequestedById as
+		| string
+		| null
+		| undefined
+	const affectedUserLogin = report?.affectedUser?.login as
+		| string
+		| null
+		| undefined
+	const assignmentRequestedByLogin = report?.assignmentRequestedBy?.login as
+		| string
+		| null
+		| undefined
 
 	const isAdmin = user?.role === "admin"
 	const myId = user?.id
@@ -60,7 +68,11 @@ export function AccordionHeader({
 	const dispatchAndRefresh = async (thunk: any, errorMessage: string) => {
 		const action = await dispatch(thunk)
 		if (action.type.endsWith("/rejected")) {
-			toast({ id: "assignment-error", title: "Erreur", description: errorMessage })
+			toast({
+				id: "assignment-error",
+				title: "Erreur",
+				description: errorMessage
+			})
 		} else {
 			refresh()
 		}
@@ -77,7 +89,8 @@ export function AccordionHeader({
 						<p className="text-xs text-green-700 font-semibold">
 							✓ Attribuée à{" "}
 							<span className="font-bold">
-								{affectedUserLogin ?? (reportUserId === myId ? "vous" : "un bénévole")}
+								{affectedUserLogin ??
+									(reportUserId === myId ? "vous" : "un bénévole")}
 							</span>
 						</p>
 						<Button
@@ -125,7 +138,8 @@ export function AccordionHeader({
 										"Impossible d'approuver la demande."
 									)
 								}}
-								className="flex-1 text-xs h-8 bg-green-600 hover:bg-green-700 text-white cursor-pointer"
+								className="flex-1 text-xs h-8 border-green-600 text-green-700 hover:bg-green-50 cursor-pointer"
+								variant="outline"
 								size="sm"
 							>
 								Approuver
@@ -138,8 +152,8 @@ export function AccordionHeader({
 										"Impossible de refuser la demande."
 									)
 								}}
-								className="flex-1 text-xs h-8 cursor-pointer"
-								variant="destructive"
+								className="flex-1 text-xs h-8 border-destructive text-destructive hover:bg-destructive/10 cursor-pointer"
+								variant="outline"
 								size="sm"
 							>
 								Refuser
@@ -188,7 +202,8 @@ export function AccordionHeader({
 						"Impossible de demander l'attribution."
 					)
 				}}
-				className="w-full text-xs h-8 bg-green-600 hover:bg-green-700 text-white cursor-pointer"
+				className="w-full text-xs h-8 cursor-pointer"
+				variant="default"
 				size="sm"
 			>
 				Demander l'attribution
@@ -197,7 +212,11 @@ export function AccordionHeader({
 	}
 
 	const renderAdminValidationSection = () => {
-		if (!isAdmin || (status !== "to_validate" && status !== "waiting_for_validation")) return null
+		if (
+			!isAdmin ||
+			(status !== "to_validate" && status !== "waiting_for_validation")
+		)
+			return null
 
 		return (
 			<div className="flex flex-col gap-1 mb-2 mt-2 p-2 bg-amber-50 rounded-md border border-amber-200">
@@ -213,7 +232,8 @@ export function AccordionHeader({
 								"Impossible de valider le signalement."
 							)
 						}}
-						className="flex-1 text-xs h-8 bg-green-600 hover:bg-green-700 text-white cursor-pointer"
+						className="flex-1 text-xs h-8 cursor-pointer"
+						variant="default"
 						size="sm"
 					>
 						Valider

--- a/frontend/src/features/clear-cut/components/form/AsideForm.tsx
+++ b/frontend/src/features/clear-cut/components/form/AsideForm.tsx
@@ -49,22 +49,22 @@ export function AsideForm({
 		}
 	}, [status, navigate, toast])
 
+	// Re-center only when the displayed report changes, not on every `value`
+	// update (e.g. the background refresh that follows a save), otherwise the
+	// map would jump back each time the form is auto-refreshed.
+	const averageCoordinates = value?.current.report.averageLocation.coordinates
+	const averageLat = averageCoordinates?.[1]
+	const averageLng = averageCoordinates?.[0]
 	useEffect(() => {
 		if (
 			map &&
 			breakpoint === "all" &&
-			value?.current.report.averageLocation.coordinates
+			averageLat !== undefined &&
+			averageLng !== undefined
 		) {
-			map.flyTo(
-				[
-					value.current.report.averageLocation.coordinates[1],
-					value.current.report.averageLocation.coordinates[0]
-				],
-				15,
-				{ duration: 1 }
-			)
+			map.flyTo([averageLat, averageLng], 15, { duration: 1 })
 		}
-	}, [breakpoint, map, value])
+	}, [breakpoint, map, averageLat, averageLng])
 
 	useEffect(() => {
 		if (value?.versionMismatchDisclaimerShown === false) {
@@ -95,10 +95,10 @@ export function AsideForm({
 			<div
 				className={cn(
 					"pt-4 px-4 pb-1 border-b-1 flex align-middle justify-between",
-					status === "loading" && "justify-end"
+					status === "loading" && !value && "justify-end"
 				)}
 			>
-				{status !== "loading" && value ? (
+				{value ? (
 					<div className="flex flex-col">
 						<Title>{`${value.current.report.city.toLocaleUpperCase()}`}</Title>
 						<span className="font-[Roboto]">
@@ -113,12 +113,12 @@ export function AsideForm({
 					<X size={30} />
 				</Link>
 			</div>
-			{status === "loading" && (
+			{status === "loading" && !value && (
 				<div className="flex h-full justify-center items-center">
 					<Loading className="w-1/2" />
 				</div>
 			)}
-			{status !== "loading" && value && <ClearCutFullForm {...value} />}
+			{value && <ClearCutFullForm {...value} />}
 		</div>
 	)
 }

--- a/frontend/src/features/clear-cut/components/form/AsideForm.tsx
+++ b/frontend/src/features/clear-cut/components/form/AsideForm.tsx
@@ -90,7 +90,7 @@ export function AsideForm({
 	return (
 		<div
 			className={cn("flex flex-col w-full bg-background", {
-				"absolute top-0 left-0 right-0 bottom-12 z-10": mobile
+				"absolute top-0 left-0 right-0 bottom-16 z-10": mobile
 			})}
 		>
 			<div

--- a/frontend/src/features/clear-cut/components/form/AsideForm.tsx
+++ b/frontend/src/features/clear-cut/components/form/AsideForm.tsx
@@ -90,7 +90,7 @@ export function AsideForm({
 	return (
 		<div
 			className={cn("flex flex-col w-full bg-background", {
-				"absolute top-0 left-0 right-0 bottom-16 z-10": mobile
+				"absolute top-0 left-0 right-0 bottom-12 z-10": mobile
 			})}
 		>
 			<div

--- a/frontend/src/features/clear-cut/components/form/AsideForm.tsx
+++ b/frontend/src/features/clear-cut/components/form/AsideForm.tsx
@@ -14,6 +14,7 @@ import { useToast } from "@/hooks/use-toast"
 import { cn } from "@/lib/utils"
 import { Loading } from "@/shared/components/Loading"
 import { Title } from "@/shared/components/typo/Title"
+import { UploadingProvider } from "@/shared/form/UploadingContext"
 import { useBreakpoint } from "@/shared/hooks/breakpoint"
 import { useAppDispatch } from "@/shared/hooks/store"
 
@@ -118,7 +119,11 @@ export function AsideForm({
 					<Loading className="w-1/2" />
 				</div>
 			)}
-			{value && <ClearCutFullForm {...value} />}
+			{value && (
+				<UploadingProvider>
+					<ClearCutFullForm {...value} />
+				</UploadingProvider>
+			)}
 		</div>
 	)
 }

--- a/frontend/src/features/clear-cut/components/form/ClearCutFullForm.tsx
+++ b/frontend/src/features/clear-cut/components/form/ClearCutFullForm.tsx
@@ -1,9 +1,9 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import { isUndefined } from "es-toolkit"
-import { Accordion } from "@/components/ui/accordion"
 import { useEffect, useMemo } from "react"
 import { FormProvider, useForm } from "react-hook-form"
 
+import { Accordion } from "@/components/ui/accordion"
 import { Button } from "@/components/ui/button"
 import {
 	Dialog,
@@ -30,7 +30,9 @@ import {
 } from "@/features/clear-cut/store/clear-cuts-slice"
 import { useConnectedMe, useMe } from "@/features/user/store/me.slice"
 import { useToast } from "@/hooks/use-toast"
+import { useUploadingTracker } from "@/shared/form/UploadingContext"
 import { useAppDispatch, useAppSelector } from "@/shared/hooks/store"
+import { useOnlineStatus } from "@/shared/hooks/useOnlineStatus"
 
 import AccordionContent from "./AccordionContent"
 import { AccordionHeader } from "./AccordionHeader"
@@ -43,6 +45,8 @@ export function ClearCutFullForm({ current, original, latest }: Props) {
 	const assignation = useAppSelector(selectAssignation)
 	const loggedUser = useMe()
 	const user = useConnectedMe()
+	const { isUploading } = useUploadingTracker()
+	const isOnline = useOnlineStatus()
 
 	const isAssignedVolunteer = useMemo(() => {
 		if (!user || user.role !== "volunteer") return false
@@ -55,14 +59,24 @@ export function ClearCutFullForm({ current, original, latest }: Props) {
 	const isDisabled = useMemo(() => {
 		if (!user) return true
 		if (user.role === "volunteer") {
-			const lockedStatuses = ["waiting_for_validation", "validated", "legal_validated", "final_validated"]
+			const lockedStatuses = [
+				"waiting_for_validation",
+				"validated",
+				"legal_validated",
+				"final_validated"
+			]
 			if (lockedStatuses.includes(current.report.status)) return true
 			const isAssignmentRequester =
 				current.report.assignmentRequestedById === user.id
 			return !isAssignedVolunteer && !isAssignmentRequester
 		}
 		return false
-	}, [user, isAssignedVolunteer, current.report.assignmentRequestedById, current.report.status])
+	}, [
+		user,
+		isAssignedVolunteer,
+		current.report.assignmentRequestedById,
+		current.report.status
+	])
 
 	const canValidate =
 		isAssignedVolunteer && current.report.status === "in_progress"
@@ -115,16 +129,30 @@ export function ClearCutFullForm({ current, original, latest }: Props) {
 		if (submission.status === "success") {
 			toast({ id: "edited-form", title: "Formulaire sauvegardé" })
 		} else if (submission.status === "error") {
-			toast({
-				id: "form-edition-error",
-				title: "Erreur lors de la sauvegarde du formulaire !"
-			})
+			// Distinguish a network outage from a server error: when offline the
+			// save simply can't reach the server, but the data is safe locally.
+			toast(
+				navigator.onLine
+					? {
+							id: "form-edition-error",
+							title: "Erreur lors de la sauvegarde du formulaire !"
+						}
+					: {
+							id: "form-edition-error",
+							title: "Sauvegarde impossible hors connexion",
+							description:
+								"Vos saisies restent enregistrées sur cet appareil. Réessayez une fois le réseau revenu."
+						}
+			)
 		}
 	}, [submission.status, toast])
 
 	useEffect(() => {
 		if (assignation.status === "success") {
-			toast({ id: "assignation-action", title: "Demande envoyée à l'administrateur" })
+			toast({
+				id: "assignation-action",
+				title: "Demande envoyée à l'administrateur"
+			})
 		} else if (assignation.status === "error") {
 			toast({
 				id: "validation-error",
@@ -168,16 +196,26 @@ export function ClearCutFullForm({ current, original, latest }: Props) {
 									⏳ Demande d'attribution en attente de validation
 								</p>
 							)}
+							{!isOnline && (
+								<p className="text-sm text-amber-600 font-medium text-center py-1">
+									📡 Hors connexion — vos saisies sont enregistrées sur cet
+									appareil.
+								</p>
+							)}
 							<Button
 								type="submit"
 								variant="outline"
 								className="w-full cursor-pointer"
 								size="lg"
-								disabled={isDisabled || submission.status === "loading"}
+								disabled={
+									isDisabled || submission.status === "loading" || isUploading
+								}
 							>
 								{submission.status === "loading"
 									? "Enregistrement..."
-									: "Sauvegarder"}
+									: isUploading
+										? "Envoi des photos en cours…"
+										: "Sauvegarder"}
 							</Button>
 							{canValidate && (
 								<Dialog>
@@ -186,7 +224,7 @@ export function ClearCutFullForm({ current, original, latest }: Props) {
 											type="button"
 											className="w-full font-bold cursor-pointer bg-green-600 hover:bg-green-700 text-white"
 											size="lg"
-											disabled={assignation.status === "loading"}
+											disabled={assignation.status === "loading" || isUploading}
 										>
 											{assignation.status === "loading"
 												? "Envoi en cours..."

--- a/frontend/src/features/clear-cut/components/form/ClearCutFullForm.tsx
+++ b/frontend/src/features/clear-cut/components/form/ClearCutFullForm.tsx
@@ -177,11 +177,11 @@ export function ClearCutFullForm({ current, original, latest }: Props) {
 						<AccordionContent original={original} form={form} latest={latest} />
 					</Accordion>
 					{!!loggedUser && (
-						<div className="flex flex-col gap-2 py-2">
+						<div className="flex flex-col gap-2 pt-2 pb-4">
 							{canRequestAssignment && (
 								<Button
 									type="button"
-									className="w-full cursor-pointer bg-green-600 hover:bg-green-700 text-white"
+									className="w-full cursor-pointer"
 									size="lg"
 									disabled={assignation.status === "loading"}
 									onClick={handleRequestAssignment}
@@ -222,7 +222,7 @@ export function ClearCutFullForm({ current, original, latest }: Props) {
 									<DialogTrigger asChild>
 										<Button
 											type="button"
-											className="w-full font-bold cursor-pointer bg-green-600 hover:bg-green-700 text-white"
+											className="w-full font-bold cursor-pointer"
 											size="lg"
 											disabled={assignation.status === "loading" || isUploading}
 										>
@@ -244,7 +244,7 @@ export function ClearCutFullForm({ current, original, latest }: Props) {
 											</DialogClose>
 											<DialogClose asChild>
 												<Button
-													className="font-bold cursor-pointer bg-green-600 hover:bg-green-700 text-white"
+													className="font-bold cursor-pointer"
 													onClick={handleValidate}
 												>
 													Valider

--- a/frontend/src/features/clear-cut/components/form/sections/OnSiteSection.tsx
+++ b/frontend/src/features/clear-cut/components/form/sections/OnSiteSection.tsx
@@ -1,6 +1,6 @@
 import type { ClearCutFormInput } from "@/features/clear-cut/store/clear-cuts"
 
-import type { FixedItem, SectionForm, SectionFormItem } from "../types"
+import type { CustomizedItem, SectionForm, SectionFormItem } from "../types"
 
 export const onSiteKey: SectionForm = {
 	name: "Terrain",
@@ -11,15 +11,30 @@ export const onSiteValue: SectionFormItem<ClearCutFormInput>[] = [
 	{
 		name: "report.affectedUser",
 		label: "Bénévole en charge du terrain :",
-		type: "fixed",
-		renderConditions: ["report.affectedUser"],
-		fallBack: (key: string | number) => (
-			<div key={key} className="sm:flex gap-2 my-2">
-				<p className="font-bold">Bénévole en charge du terrain : </p>
-				<p>Aucun bénévole n'est assigné</p>
-			</div>
-		)
-	} satisfies FixedItem<ClearCutFormInput, "report.affectedUser">,
+		type: "customized",
+		// Always true so customizeRender always runs while staying out of the
+		// generic value/disabled test loops (which target renderConditions.length === 0).
+		renderConditions: ["report.id"],
+		customizeRender: (form, key) => {
+			const affectedUser = form.getValues("report.affectedUser")
+			const userId = form.getValues("report.userId")
+			// `affectedUser` is hidden by the backend for users who can't see the
+			// assignment (privacy gating), but `userId` is still exposed. Distinguish
+			// "assigned to someone else (name hidden)" from "truly unassigned" to stay
+			// consistent with the header badge.
+			const display = affectedUser?.login
+				? affectedUser.login
+				: userId
+					? "Attribuée à un autre bénévole"
+					: "Aucun bénévole n'est assigné"
+			return (
+				<div key={key} className="sm:flex gap-2 my-2">
+					<p className="font-bold">Bénévole en charge du terrain : </p>
+					<p>{display}</p>
+				</div>
+			)
+		}
+	} satisfies CustomizedItem<ClearCutFormInput, "report.affectedUser">,
 	{
 		name: "inspectionDate",
 		label: "Date du terrain",

--- a/frontend/src/features/clear-cut/components/list/AsideList.tsx
+++ b/frontend/src/features/clear-cut/components/list/AsideList.tsx
@@ -1,4 +1,4 @@
-import { Filter, MapIcon } from "lucide-react"
+import { Filter } from "lucide-react"
 import { useState } from "react"
 
 import {
@@ -24,7 +24,7 @@ import { useAppDispatch, useAppSelector } from "@/shared/hooks/store"
 
 export function AsideList({ mobile = false }: { mobile?: boolean }) {
 	const { value } = useAppSelector(selectClearCuts)
-	const { layout, setLayout } = useLayout()
+	const { layout } = useLayout()
 	const dispatch = useAppDispatch()
 	const resetVersion = useAppSelector(selectResetVersion)
 	const sortOrder = useAppSelector(selectSortOrder)
@@ -39,16 +39,6 @@ export function AsideList({ mobile = false }: { mobile?: boolean }) {
 			<span className="hidden min-[420px]:inline">Date de coupe</span>
 			<span className="min-[420px]:hidden">Date</span>
 		</SortingButton>
-	)
-
-	const mapToggle = (
-		<IconButton
-			variant="outline"
-			onClick={() => setLayout("map")}
-			icon={<MapIcon />}
-			title="Afficher la carte"
-			position="start"
-		/>
 	)
 
 	const filtersButton = (
@@ -93,7 +83,6 @@ export function AsideList({ mobile = false }: { mobile?: boolean }) {
 						<div className="flex gap-2 shrink-0">
 							{sortButton}
 							<SheetTrigger asChild>{filtersButton}</SheetTrigger>
-							{mapToggle}
 						</div>
 					</div>
 					<SheetContent title="Filtres">
@@ -121,7 +110,6 @@ export function AsideList({ mobile = false }: { mobile?: boolean }) {
 					<div className="flex gap-2 shrink-0">
 						{sortButton}
 						<CollapsibleTrigger asChild>{filtersButton}</CollapsibleTrigger>
-						{mapToggle}
 					</div>
 				</div>
 				<CollapsibleContent

--- a/frontend/src/features/clear-cut/components/list/AsideList.tsx
+++ b/frontend/src/features/clear-cut/components/list/AsideList.tsx
@@ -1,10 +1,12 @@
 import { Filter, MapIcon } from "lucide-react"
+import { useState } from "react"
 
 import {
 	Collapsible,
 	CollapsibleContent,
 	CollapsibleTrigger
 } from "@/components/ui/collapsible"
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 import { AdvancedFilters } from "@/features/clear-cut/components/filters/AdvancedFilters"
 import { useLayout } from "@/features/clear-cut/components/Layout.context"
 import { ClearCutItem } from "@/features/clear-cut/components/list/ClearCutItem"
@@ -26,47 +28,100 @@ export function AsideList({ mobile = false }: { mobile?: boolean }) {
 	const dispatch = useAppDispatch()
 	const resetVersion = useAppSelector(selectResetVersion)
 	const sortOrder = useAppSelector(selectSortOrder)
+	const [filtersOpen, setFiltersOpen] = useState(false)
 	const isShown = layout === "list"
 
-	return (
-		<div
-			className={cn("flex flex-col w-full bg-background", {
-				hidden: !isShown,
-				"absolute top-0 left-0 right-0 bottom-16 z-10": isShown && mobile,
-				"h-auto": !(isShown && mobile)
-			})}
+	const sortButton = (
+		<SortingButton
+			sort={sortOrder}
+			onClick={() => dispatch(filtersSlice.actions.toggleSortOrder())}
 		>
+			<span className="hidden min-[420px]:inline">Date de coupe</span>
+			<span className="min-[420px]:hidden">Date</span>
+		</SortingButton>
+	)
+
+	const mapToggle = (
+		<IconButton
+			variant="outline"
+			onClick={() => setLayout("map")}
+			icon={<MapIcon />}
+			title="Afficher la carte"
+			position="start"
+		/>
+	)
+
+	const filtersButton = (
+		<IconButton
+			variant="outline"
+			icon={<Filter />}
+			position="start"
+			title="Filtres"
+		>
+			<span className="hidden min-[420px]:inline">Filtres</span>
+		</IconButton>
+	)
+
+	const list = (
+		<div className="overflow-auto">
+			<ul className="flex flex-col">
+				{value?.previews.map((preview) => (
+					<ClearCutItem key={preview.id} {...preview} />
+				))}
+			</ul>
+		</div>
+	)
+
+	const headerClassName =
+		"flex justify-between items-center gap-2 mt-1 sm:mt-2 border-b-1 border-zinc-200 px-3 py-2"
+	const containerClassName = cn("flex flex-col w-full bg-background", {
+		hidden: !isShown,
+		"absolute top-0 left-0 right-0 bottom-16 z-10": isShown && mobile,
+		"h-auto": !(isShown && mobile)
+	})
+
+	// On mobile the filters live in a bottom sheet (more room, no inline shift);
+	// on desktop they stay in an inline collapsible panel under the header.
+	if (mobile) {
+		return (
+			<div className={containerClassName}>
+				<Sheet open={filtersOpen} onOpenChange={setFiltersOpen}>
+					<div className={headerClassName}>
+						<Title className="text-primary truncate min-w-0 text-lg sm:text-xl">
+							COUPES RASES
+						</Title>
+						<div className="flex gap-2 shrink-0">
+							{sortButton}
+							<SheetTrigger asChild>{filtersButton}</SheetTrigger>
+							{mapToggle}
+						</div>
+					</div>
+					<SheetContent title="Filtres">
+						<div className="overflow-y-auto">
+							<AdvancedFilters
+								key={resetVersion}
+								className="px-1 bg-background"
+								onClose={() => setFiltersOpen(false)}
+							/>
+						</div>
+					</SheetContent>
+				</Sheet>
+				{list}
+			</div>
+		)
+	}
+
+	return (
+		<div className={containerClassName}>
 			<Collapsible>
-				<div className="flex justify-between items-center gap-2 mt-1 sm:mt-2 border-b-1 border-zinc-200 px-3 py-2">
+				<div className={headerClassName}>
 					<Title className="text-primary truncate min-w-0 text-lg sm:text-xl">
 						COUPES RASES
 					</Title>
 					<div className="flex gap-2 shrink-0">
-						<SortingButton
-							sort={sortOrder}
-							onClick={() => dispatch(filtersSlice.actions.toggleSortOrder())}
-						>
-							<span className="hidden min-[420px]:inline">Date de coupe</span>
-							<span className="min-[420px]:hidden">Date</span>
-						</SortingButton>
-						<CollapsibleTrigger asChild>
-							<IconButton
-								variant="outline"
-								icon={<Filter />}
-								position="start"
-								title="Filtres"
-								className="[data-state=open]:bg-purple-400"
-							>
-								<span className="hidden min-[420px]:inline">Filtres</span>
-							</IconButton>
-						</CollapsibleTrigger>
-						<IconButton
-							variant="outline"
-							onClick={() => setLayout("map")}
-							icon={<MapIcon />}
-							title="Afficher la carte"
-							position="start"
-						/>
+						{sortButton}
+						<CollapsibleTrigger asChild>{filtersButton}</CollapsibleTrigger>
+						{mapToggle}
 					</div>
 				</div>
 				<CollapsibleContent
@@ -81,14 +136,7 @@ export function AsideList({ mobile = false }: { mobile?: boolean }) {
 					<AdvancedFilters key={resetVersion} className="px-3" />
 				</CollapsibleContent>
 			</Collapsible>
-
-			<div className="overflow-auto">
-				<ul className="flex flex-col">
-					{value?.previews.map((preview) => (
-						<ClearCutItem key={preview.id} {...preview} />
-					))}
-				</ul>
-			</div>
+			{list}
 		</div>
 	)
 }

--- a/frontend/src/features/clear-cut/components/list/AsideList.tsx
+++ b/frontend/src/features/clear-cut/components/list/AsideList.tsx
@@ -32,33 +32,36 @@ export function AsideList({ mobile = false }: { mobile?: boolean }) {
 		<div
 			className={cn("flex flex-col w-full bg-background", {
 				hidden: !isShown,
-				"absolute top-0 left-0 right-0 bottom-12 z-10": isShown && mobile,
+				"absolute top-0 left-0 right-0 bottom-16 z-10": isShown && mobile,
 				"h-auto": !(isShown && mobile)
 			})}
 		>
 			<Collapsible>
-				<div className="flex justify-between items-center mt-1 sm:mt-2 border-b-1 border-zinc-200 px-3 py-2">
-					<Title className="text-primary">COUPES RASES</Title>
-					<div className="flex gap-2">
+				<div className="flex justify-between items-center gap-2 mt-1 sm:mt-2 border-b-1 border-zinc-200 px-3 py-2">
+					<Title className="text-primary truncate min-w-0 text-lg sm:text-xl">
+						COUPES RASES
+					</Title>
+					<div className="flex gap-2 shrink-0">
 						<SortingButton
 							sort={sortOrder}
 							onClick={() => dispatch(filtersSlice.actions.toggleSortOrder())}
 						>
-							Date de coupe
+							<span className="hidden min-[420px]:inline">Date de coupe</span>
+							<span className="min-[420px]:hidden">Date</span>
 						</SortingButton>
 						<CollapsibleTrigger asChild>
 							<IconButton
 								variant="outline"
 								icon={<Filter />}
 								position="start"
+								title="Filtres"
 								className="[data-state=open]:bg-purple-400"
 							>
-								Filtres
+								<span className="hidden min-[420px]:inline">Filtres</span>
 							</IconButton>
 						</CollapsibleTrigger>
 						<IconButton
 							variant="outline"
-							// className="sm:hidden"
 							onClick={() => setLayout("map")}
 							icon={<MapIcon />}
 							title="Afficher la carte"

--- a/frontend/src/features/clear-cut/components/list/AsideList.tsx
+++ b/frontend/src/features/clear-cut/components/list/AsideList.tsx
@@ -9,16 +9,23 @@ import { AdvancedFilters } from "@/features/clear-cut/components/filters/Advance
 import { useLayout } from "@/features/clear-cut/components/Layout.context"
 import { ClearCutItem } from "@/features/clear-cut/components/list/ClearCutItem"
 import { selectClearCuts } from "@/features/clear-cut/store/clear-cuts-slice"
-import { selectResetVersion } from "@/features/clear-cut/store/filters.slice"
+import {
+	filtersSlice,
+	selectResetVersion,
+	selectSortOrder
+} from "@/features/clear-cut/store/filters.slice"
 import { cn } from "@/lib/utils"
 import { IconButton } from "@/shared/components/button/Button"
+import { SortingButton } from "@/shared/components/button/SortingButton"
 import { Title } from "@/shared/components/typo/Title"
-import { useAppSelector } from "@/shared/hooks/store"
+import { useAppDispatch, useAppSelector } from "@/shared/hooks/store"
 
 export function AsideList({ mobile = false }: { mobile?: boolean }) {
 	const { value } = useAppSelector(selectClearCuts)
 	const { layout, setLayout } = useLayout()
+	const dispatch = useAppDispatch()
 	const resetVersion = useAppSelector(selectResetVersion)
+	const sortOrder = useAppSelector(selectSortOrder)
 	const isShown = layout === "list"
 
 	return (
@@ -33,6 +40,12 @@ export function AsideList({ mobile = false }: { mobile?: boolean }) {
 				<div className="flex justify-between items-center mt-1 sm:mt-2 border-b-1 border-zinc-200 px-3 py-2">
 					<Title className="text-primary">COUPES RASES</Title>
 					<div className="flex gap-2">
+						<SortingButton
+							sort={sortOrder}
+							onClick={() => dispatch(filtersSlice.actions.toggleSortOrder())}
+						>
+							Date de coupe
+						</SortingButton>
 						<CollapsibleTrigger asChild>
 							<IconButton
 								variant="outline"

--- a/frontend/src/features/clear-cut/components/list/AsideList.tsx
+++ b/frontend/src/features/clear-cut/components/list/AsideList.tsx
@@ -54,7 +54,7 @@ export function AsideList({ mobile = false }: { mobile?: boolean }) {
 
 	const list = (
 		<div className="overflow-auto">
-			<ul className="flex flex-col">
+			<ul aria-label="Liste des coupes rases" className="flex flex-col">
 				{value?.previews.map((preview) => (
 					<ClearCutItem key={preview.id} {...preview} />
 				))}

--- a/frontend/src/features/clear-cut/components/map/ClearCutMapPopUp.tsx
+++ b/frontend/src/features/clear-cut/components/map/ClearCutMapPopUp.tsx
@@ -83,9 +83,11 @@ export function ClearCutMapPopUp({
 		id,
 		userId,
 		assignmentRequestedById
-	}
+	},
+	isReportPanelOpen = false
 }: {
 	report: ClearCutReport
+	isReportPanelOpen?: boolean
 }) {
 	const dispatch = useAppDispatch()
 	const user = useConnectedMe()
@@ -204,12 +206,13 @@ export function ClearCutMapPopUp({
 		<Popup
 			ref={popupRef}
 			closeButton={false}
-			maxWidth={350}
+			maxWidth={280}
+			autoPan={false}
 			eventHandlers={{ add: disablePopupPropagation }}
 		>
-			<div className="flex justify-between items-center gap-2 mb-5 w-full font-inter">
+			<div className="flex justify-between items-center gap-2 mb-3 w-full font-inter">
 				<div className="flex items-center">
-					<h2 className="font-semibold text-lg">{name ?? city}</h2>
+					<h2 className="font-semibold text-base">{name ?? city}</h2>
 					<DotByStatus className="ml-2.5" status={status} />
 				</div>
 				<button
@@ -226,13 +229,13 @@ export function ClearCutMapPopUp({
 				</button>
 			</div>
 
-			<div className="flex mb-5 gap-2 font-inter">
+			<div className="flex mb-3 gap-2 font-inter">
 				{tags.map((tag) => (
 					<RuleBadge key={tag.id} {...tag} />
 				))}
 			</div>
 
-			<div className="flex flex-col gap-2.5 text-base text-secondary font-jakarta font-medium">
+			<div className="flex flex-col gap-2 text-sm text-secondary font-jakarta font-medium">
 				<div>
 					Début de la coupe :{" "}
 					<strong>
@@ -285,24 +288,28 @@ export function ClearCutMapPopUp({
 				/>
 			</div>
 
-			<div className="flex flex-col gap-2 mt-4 pt-3 border-t border-neutral-100">
+			<div className="flex flex-col gap-2 mt-3 pt-3 border-t border-neutral-100">
 				{renderAssignmentSection()}
-				<Button
-					type="button"
-					variant="outline"
-					size="sm"
-					onClick={(e) => {
-						e.stopPropagation()
-						e.nativeEvent.stopImmediatePropagation()
-						navigate({
-							to: "/clear-cuts/$clearCutId",
-							params: { clearCutId: id }
-						})
-					}}
-					className="w-full text-xs min-h-[44px] cursor-pointer"
-				>
-					Renseigner les informations
-				</Button>
+				{/* Hidden when the side info panel is already open for this report:
+				    the button would just re-open the panel it is already showing. */}
+				{!isReportPanelOpen && (
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						onClick={(e) => {
+							e.stopPropagation()
+							e.nativeEvent.stopImmediatePropagation()
+							navigate({
+								to: "/clear-cuts/$clearCutId",
+								params: { clearCutId: id }
+							})
+						}}
+						className="w-full text-xs min-h-[44px] cursor-pointer"
+					>
+						Renseigner les informations
+					</Button>
+				)}
 			</div>
 		</Popup>
 	)

--- a/frontend/src/features/clear-cut/components/map/ClearCutMapPopUp.tsx
+++ b/frontend/src/features/clear-cut/components/map/ClearCutMapPopUp.tsx
@@ -183,7 +183,7 @@ export function ClearCutMapPopUp({
 							"Impossible de demander l'attribution."
 						)
 					}}
-					className="w-full text-xs min-h-[44px] bg-green-600 hover:bg-green-700 text-white cursor-pointer"
+					className="w-full text-xs min-h-[44px] cursor-pointer"
 					size="sm"
 				>
 					Demander l'attribution

--- a/frontend/src/features/clear-cut/components/map/ClearCutPreview.tsx
+++ b/frontend/src/features/clear-cut/components/map/ClearCutPreview.tsx
@@ -1,6 +1,7 @@
 import { useLocation } from "@tanstack/react-router"
-import { type RefObject, useEffect, useRef } from "react"
-import { GeoJSON } from "react-leaflet"
+import L from "leaflet"
+import { type RefObject, useEffect, useMemo, useRef } from "react"
+import { GeoJSON, Marker } from "react-leaflet"
 
 import { ClearCutMapPopUp } from "@/features/clear-cut/components/map/ClearCutMapPopUp"
 import { useMapInstance } from "@/features/clear-cut/components/map/Map.context"
@@ -42,32 +43,60 @@ export function ClearCutPreview({ report, clearCut }: Props) {
 	const weight = isFocused ? 2 : 0
 	const fillOpacity = isFocused ? 0.25 : 0.5
 
+	// "i" badge displayed on the zone to hint that clicking reveals its details.
+	// (The popup no longer opens on hover, so this invites the click instead.)
+	const infoIcon = useMemo(
+		() =>
+			L.divIcon({
+				className: "clear-cut-info-icon",
+				html: '<span aria-hidden="true">i</span>',
+				iconSize: [22, 22],
+				iconAnchor: [11, 11]
+			}),
+		[]
+	)
+	const iconPosition = useMemo<[number, number]>(
+		() => [clearCut.location.coordinates[1], clearCut.location.coordinates[0]],
+		[clearCut.location.coordinates]
+	)
+
 	return (
-		<GeoJSON
-			key={clearCut.id}
-			ref={ref as RefObject<L.GeoJSON>}
-			data={clearCut.boundary}
-			style={{
-				color: `var(--color-${CLEAR_CUTTING_STATUS_COLORS[report.status]})`,
-				weight,
-				fillOpacity
-			}}
-			eventHandlers={{
-				mouseover: (event) => {
-					event.target.openPopup()
-				},
-				dblclick: () => {
-					navigateToDetail()
-				},
-				click: () => {
-					navigateToDetail()
-				},
-				popupopen: () => {
-					setFocusedClearCutId(report.id)
-				}
-			}}
-		>
-			<ClearCutMapPopUp report={report} />
-		</GeoJSON>
+		<>
+			<GeoJSON
+				key={clearCut.id}
+				ref={ref as RefObject<L.GeoJSON>}
+				data={clearCut.boundary}
+				style={{
+					color: `var(--color-${CLEAR_CUTTING_STATUS_COLORS[report.status]})`,
+					weight,
+					fillOpacity
+				}}
+				eventHandlers={{
+					dblclick: () => {
+						navigateToDetail()
+					},
+					click: () => {
+						navigateToDetail()
+					},
+					popupopen: () => {
+						setFocusedClearCutId(report.id)
+					}
+				}}
+			>
+				<ClearCutMapPopUp
+					report={report}
+					isReportPanelOpen={reportIsOpenInSideList}
+				/>
+			</GeoJSON>
+			<Marker
+				position={iconPosition}
+				icon={infoIcon}
+				interactive
+				keyboard={false}
+				eventHandlers={{
+					click: () => navigateToDetail()
+				}}
+			/>
+		</>
 	)
 }

--- a/frontend/src/features/clear-cut/components/map/ClearCuts.tsx
+++ b/frontend/src/features/clear-cut/components/map/ClearCuts.tsx
@@ -1,5 +1,5 @@
 import * as L from "leaflet"
-import { Layers, ListIcon } from "lucide-react"
+import { Layers, ListIcon, Map as MapIcon } from "lucide-react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { CircleMarker, useMap, useMapEvents } from "react-leaflet"
 
@@ -22,10 +22,8 @@ import {
 	setWithPoints
 } from "@/features/clear-cut/store/filters.slice"
 import { cn } from "@/lib/utils"
-import { IconButton } from "@/shared/components/button/Button"
 import { AddressInput } from "@/shared/components/input/AddressInput"
 import { ToggleGroup } from "@/shared/components/toggle-group/ToggleGroup"
-import { useBreakpoint } from "@/shared/hooks/breakpoint"
 import { useAppDispatch, useAppSelector } from "@/shared/hooks/store"
 import { type SelectableItemEnhanced, useSingleSelect } from "@/shared/items"
 
@@ -97,7 +95,6 @@ export function ClearCuts() {
 	const map = useMap()
 	const { setFocusedClearCutId, focusedClearCutId, setMap } = useMapInstance()
 	const { layout, setLayout } = useLayout()
-	const { breakpoint } = useBreakpoint()
 	useEffect(() => {
 		setMap(map)
 		return () => setMap(null)
@@ -237,15 +234,39 @@ export function ClearCuts() {
 		}
 	}, [displayPoints, value?.points, map])
 
-	const iconButton = (
-		<IconButton
-			variant="white"
-			className="mx-1"
-			onClick={() => setLayout("list")}
-			icon={<ListIcon />}
-			title="Afficher la liste"
-			position="start"
-		/>
+	// Desktop: a single persistent segmented control replaces the lone, ambiguous
+	// toggle icon. Mobile switches map/list via the bottom navbar instead.
+	const segmentClassName =
+		"inline-flex items-center gap-1.5 rounded h-8 px-3 text-sm font-medium transition-colors"
+	const layoutToggle = (
+		<div className="hidden sm:flex items-center gap-0.5 rounded-md border bg-white p-0.5 shadow-md">
+			<button
+				type="button"
+				onClick={() => setLayout("map")}
+				className={cn(
+					segmentClassName,
+					layout === "map"
+						? "bg-primary text-primary-foreground"
+						: "text-zinc-600 hover:bg-zinc-100"
+				)}
+			>
+				<MapIcon className="size-4" />
+				Carte
+			</button>
+			<button
+				type="button"
+				onClick={() => setLayout("list")}
+				className={cn(
+					segmentClassName,
+					layout === "list"
+						? "bg-primary text-primary-foreground"
+						: "text-zinc-600 hover:bg-zinc-100"
+				)}
+			>
+				<ListIcon className="size-4" />
+				Liste
+			</button>
+		</div>
 	)
 	return (
 		<>
@@ -256,10 +277,9 @@ export function ClearCuts() {
 					</div>
 					<div className="justify-end w-full flex flex-row gap-1">
 						<LocationButton className="hidden sm:flex" />
-						{breakpoint === "all" && layout === "map" && iconButton}
+						{layoutToggle}
 						<MobileControl clearCutId={focusedClearCutId}>
 							<LocationButton />
-							{iconButton}
 						</MobileControl>
 					</div>
 				</div>

--- a/frontend/src/features/clear-cut/components/map/ClearCuts.tsx
+++ b/frontend/src/features/clear-cut/components/map/ClearCuts.tsx
@@ -1,10 +1,17 @@
 import * as L from "leaflet"
-import { ListIcon, Locate } from "lucide-react"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { Layers, ListIcon } from "lucide-react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { CircleMarker, useMap, useMapEvents } from "react-leaflet"
 
+import { buttonVariants } from "@/components/ui/button"
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger
+} from "@/components/ui/popover"
 import { useLayout } from "@/features/clear-cut/components/Layout.context"
 import { ClearCutPreview } from "@/features/clear-cut/components/map/ClearCutPreview"
+import { LocationButton } from "@/features/clear-cut/components/map/LocationButton"
 import { useMapInstance } from "@/features/clear-cut/components/map/Map.context"
 import { MobileControl } from "@/features/clear-cut/components/map/MobileControl"
 import { DISPLAY_PREVIEW_ZOOM_LEVEL } from "@/features/clear-cut/store/clear-cuts"
@@ -14,11 +21,11 @@ import {
 	setGeoBounds,
 	setWithPoints
 } from "@/features/clear-cut/store/filters.slice"
+import { cn } from "@/lib/utils"
 import { IconButton } from "@/shared/components/button/Button"
 import { AddressInput } from "@/shared/components/input/AddressInput"
 import { ToggleGroup } from "@/shared/components/toggle-group/ToggleGroup"
 import { useBreakpoint } from "@/shared/hooks/breakpoint"
-import { useGeolocation } from "@/shared/hooks/geolocation"
 import { useAppDispatch, useAppSelector } from "@/shared/hooks/store"
 import { type SelectableItemEnhanced, useSingleSelect } from "@/shared/items"
 
@@ -101,7 +108,14 @@ export function ClearCuts() {
 		map.zoomControl.setPosition("bottomright")
 	}, [map])
 
-	const { browserLocation } = useGeolocation()
+	// Keep clicks/scrolls on the layers control from bubbling into map pan/zoom.
+	const layersControlRef = useRef<HTMLDivElement>(null)
+	useEffect(() => {
+		if (!layersControlRef.current) return
+		L.DomEvent.disableClickPropagation(layersControlRef.current)
+		L.DomEvent.disableScrollPropagation(layersControlRef.current)
+	}, [])
+
 	const displayPoints = useAppSelector(selectWithPoints)
 	const [layer, layers, setLayer] = useSingleSelect<
 		L.TileLayer,
@@ -139,15 +153,6 @@ export function ClearCuts() {
 		}
 		setOverlays(selectedItems)
 	}
-
-	const centerOnUserLocation = useCallback(() => {
-		if (browserLocation) {
-			map.setView({
-				lat: browserLocation.coords.latitude,
-				lng: browserLocation.coords.longitude
-			})
-		}
-	}, [browserLocation, map.setView])
 
 	const dispatch = useAppDispatch()
 
@@ -249,46 +254,64 @@ export function ClearCuts() {
 					<div className="w-full sm:max-w-100">
 						<AddressInput onSelect={centerOnCoordinates} />
 					</div>
-					<div className="justify-end w-full flex flex-row">
-						{browserLocation && (
-							<IconButton
-								icon={<Locate />}
-								className="hidden sm:flex"
-								onClick={centerOnUserLocation}
-								position={"end"}
-							>
-								Centrer sur ma position
-							</IconButton>
-						)}
+					<div className="justify-end w-full flex flex-row gap-1">
+						<LocationButton className="hidden sm:flex" />
 						{breakpoint === "all" && layout === "map" && iconButton}
 						<MobileControl clearCutId={focusedClearCutId}>
-							<IconButton
-								icon={<Locate />}
-								onClick={centerOnUserLocation}
-								position={"end"}
-							/>
+							<LocationButton />
 							{iconButton}
 						</MobileControl>
 					</div>
 				</div>
 			</div>
 			<div className="leaflet-bottom leaflet-left mb-3">
-				<div className="leaflet-control bg-zinc-100 p-1 rounded-md flex flex-col gap-1">
-					<ToggleGroup
-						variant="primary"
-						type="single"
-						allowEmptyValue={false}
-						size="sm"
-						value={layers}
-						onValueChange={handleLayerSelected}
-					/>
-					<ToggleGroup
-						variant="primary"
-						type="multiple"
-						size="sm"
-						value={overlays}
-						onValueChange={handleOverlaysChanged}
-					/>
+				<div ref={layersControlRef} className="leaflet-control">
+					<Popover>
+						<PopoverTrigger asChild>
+							<button
+								type="button"
+								title="Fonds de carte et calques"
+								aria-label="Fonds de carte et calques"
+								className={cn(
+									buttonVariants({ variant: "white" }),
+									"size-10 p-0 shadow-md"
+								)}
+							>
+								<Layers className="size-5" />
+							</button>
+						</PopoverTrigger>
+						<PopoverContent
+							side="top"
+							align="start"
+							className="w-auto p-3 flex flex-col gap-3"
+						>
+							<div className="flex flex-col gap-1">
+								<span className="text-[10px] font-semibold uppercase tracking-wide text-zinc-500">
+									Fond de carte
+								</span>
+								<ToggleGroup
+									variant="primary"
+									type="single"
+									allowEmptyValue={false}
+									size="sm"
+									value={layers}
+									onValueChange={handleLayerSelected}
+								/>
+							</div>
+							<div className="flex flex-col gap-1">
+								<span className="text-[10px] font-semibold uppercase tracking-wide text-zinc-500">
+									Calques
+								</span>
+								<ToggleGroup
+									variant="primary"
+									type="multiple"
+									size="sm"
+									value={overlays}
+									onValueChange={handleOverlaysChanged}
+								/>
+							</div>
+						</PopoverContent>
+					</Popover>
 				</div>
 			</div>
 			{previews}

--- a/frontend/src/features/clear-cut/components/map/InteractiveMap.tsx
+++ b/frontend/src/features/clear-cut/components/map/InteractiveMap.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils"
 
 import "@geoman-io/leaflet-geoman-free"
 import "@geoman-io/leaflet-geoman-free/dist/leaflet-geoman.css"
+import { useNavigate } from "@tanstack/react-router"
 import { useState } from "react"
 import { useMap } from "react-leaflet"
 
@@ -20,18 +21,14 @@ import {
 	DialogTitle
 } from "@/components/ui/dialog"
 import { Label } from "@/components/ui/label"
-import { useToast } from "@/hooks/use-toast"
-import { useConnectedMe } from "@/features/user/store/me.slice"
-
 import { getClearCutsThunk } from "@/features/clear-cut/store/clear-cuts-slice"
 import { selectFiltersRequest } from "@/features/clear-cut/store/filters.slice"
+import { getStoredToken, useConnectedMe } from "@/features/user/store/me.slice"
+import { useToast } from "@/hooks/use-toast"
 import { api } from "@/shared/api/api"
-import { getStoredToken } from "@/features/user/store/me.slice"
 import { useAppDispatch, useAppSelector } from "@/shared/hooks/store"
-import { useNavigate } from "@tanstack/react-router"
 
 import { ClearCuts } from "./ClearCuts"
-import { LocationButton } from "./LocationButton"
 
 function authedApi() {
 	const token = getStoredToken() as any
@@ -47,8 +44,14 @@ function GeomanControls() {
 	const [isOpen, setIsOpen] = useState(false)
 	const [_geometry, setGeometry] = useState<any>(null)
 	const [citySearch, setCitySearch] = useState("")
-	const [cityResults, setCityResults] = useState<{ insee_code: string; name: string; department_code: string }[]>([])
-	const [selectedCity, setSelectedCity] = useState<{ insee_code: string; name: string; department_code: string } | null>(null)
+	const [cityResults, setCityResults] = useState<
+		{ insee_code: string; name: string; department_code: string }[]
+	>([])
+	const [selectedCity, setSelectedCity] = useState<{
+		insee_code: string
+		name: string
+		department_code: string
+	} | null>(null)
 	const [isSubmitting, setIsSubmitting] = useState(false)
 
 	const dispatch = useAppDispatch()
@@ -110,7 +113,9 @@ function GeomanControls() {
 			try {
 				const results = await authedApi()
 					.get("api/v1/cities/search", { searchParams: { q: citySearch } })
-					.json<{ insee_code: string; name: string; department_code: string }[]>()
+					.json<
+						{ insee_code: string; name: string; department_code: string }[]
+					>()
 				setCityResults(results)
 			} catch {
 				setCityResults([])
@@ -156,11 +161,15 @@ function GeomanControls() {
 			})
 			handleDialogClose(false)
 			if (filters) dispatch(getClearCutsThunk(filters))
-			navigate({ to: "/clear-cuts/$clearCutId", params: { clearCutId: response.id } })
+			navigate({
+				to: "/clear-cuts/$clearCutId",
+				params: { clearCutId: response.id }
+			})
 		} catch {
 			toast({
 				title: "Erreur",
-				description: "Impossible de créer le signalement. Vérifiez que la géométrie est valide.",
+				description:
+					"Impossible de créer le signalement. Vérifiez que la géométrie est valide.",
 				variant: "destructive"
 			})
 		} finally {
@@ -184,7 +193,11 @@ function GeomanControls() {
 							<input
 								id="citySearch"
 								placeholder="Ex: Limoges, Saint-Étienne..."
-								value={selectedCity ? `${selectedCity.name} (${selectedCity.department_code})` : citySearch}
+								value={
+									selectedCity
+										? `${selectedCity.name} (${selectedCity.department_code})`
+										: citySearch
+								}
 								onChange={(e: any) => {
 									setSelectedCity(null)
 									setCitySearch(e.target.value)
@@ -206,7 +219,9 @@ function GeomanControls() {
 											}}
 										>
 											{city.name}
-											<span className="ml-1 text-neutral-400 text-xs">({city.department_code})</span>
+											<span className="ml-1 text-neutral-400 text-xs">
+												({city.department_code})
+											</span>
 										</li>
 									))}
 								</ul>
@@ -222,7 +237,10 @@ function GeomanControls() {
 					>
 						Annuler
 					</Button>
-					<Button onClick={handleSubmit} disabled={isSubmitting || !selectedCity}>
+					<Button
+						onClick={handleSubmit}
+						disabled={isSubmitting || !selectedCity}
+					>
 						{isSubmitting ? "Envoi..." : "Valider le signalement"}
 					</Button>
 				</DialogFooter>
@@ -262,7 +280,6 @@ export function InteractiveMap() {
 				url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
 			/>
 			<GeomanControls />
-			<LocationButton />
 			<ClearCuts />
 		</MapContainer>
 	)

--- a/frontend/src/features/clear-cut/components/map/LocationButton.tsx
+++ b/frontend/src/features/clear-cut/components/map/LocationButton.tsx
@@ -3,10 +3,16 @@ import { Loader2, LocateFixed } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import { useMap } from "react-leaflet"
 
+import { buttonVariants } from "@/components/ui/button"
 import { useToast } from "@/hooks/use-toast"
 import { cn } from "@/lib/utils"
 
-export function LocationButton() {
+/**
+ * Single geolocation control. One tap locates + recenters the map and starts
+ * live tracking; tapping again stops tracking. Rendered inline inside the map
+ * control row (not absolutely positioned) so it never overlaps other controls.
+ */
+export function LocationButton({ className }: { className?: string }) {
 	const map = useMap()
 	const { toast } = useToast()
 	const buttonRef = useRef<HTMLButtonElement>(null)
@@ -128,17 +134,12 @@ export function LocationButton() {
 			type="button"
 			onClick={handleClick}
 			disabled={isLocating}
-			aria-label={isTracking ? "Désactiver ma position" : "Me géolocaliser"}
+			aria-label={isTracking ? "Désactiver ma position" : "Me localiser"}
+			title={isTracking ? "Désactiver le suivi de position" : "Me localiser"}
 			className={cn(
-				"absolute top-20 right-4 z-[1000]",
-				"flex items-center gap-2 rounded-full px-4 py-3 sm:px-5",
-				"text-sm font-semibold",
-				"shadow-xl ring-2 ring-white",
-				"transition active:scale-95",
-				"disabled:cursor-wait",
-				isTracking
-					? "bg-emerald-600 text-white hover:bg-emerald-700"
-					: "bg-blue-600 text-white hover:bg-blue-700"
+				buttonVariants({ variant: isTracking ? "default" : "white" }),
+				"shrink-0 active:scale-95 disabled:cursor-wait",
+				className
 			)}
 		>
 			{isLocating ? (
@@ -146,7 +147,9 @@ export function LocationButton() {
 			) : (
 				<LocateFixed size={20} />
 			)}
-			<span>{isTracking ? "Position active" : "Me localiser"}</span>
+			<span className="hidden sm:inline">
+				{isTracking ? "Position active" : "Me localiser"}
+			</span>
 		</button>
 	)
 }

--- a/frontend/src/features/clear-cut/components/map/MobileControl.tsx
+++ b/frontend/src/features/clear-cut/components/map/MobileControl.tsx
@@ -1,13 +1,9 @@
-import {
-	Collapsible,
-	CollapsibleContent,
-	CollapsibleTrigger
-} from "@radix-ui/react-collapsible"
 import { useNavigate } from "@tanstack/react-router"
 import { Filter } from "lucide-react"
-import type { PropsWithChildren } from "react"
+import { type PropsWithChildren, useState } from "react"
 
 import { Button } from "@/components/ui/button"
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 import { AdvancedFilters } from "@/features/clear-cut/components/filters/AdvancedFilters"
 import { selectResetVersion } from "@/features/clear-cut/store/filters.slice"
 import { IconButton } from "@/shared/components/button/Button"
@@ -18,8 +14,9 @@ type Props = PropsWithChildren<{ clearCutId?: string }>
 export function MobileControl({ clearCutId, children }: Props) {
 	const navigate = useNavigate()
 	const resetVersion = useAppSelector(selectResetVersion)
+	const [open, setOpen] = useState(false)
 	return (
-		<Collapsible>
+		<Sheet open={open} onOpenChange={setOpen}>
 			<div className="flex justify-end sm:hidden">
 				{children}
 				{clearCutId && (
@@ -35,16 +32,22 @@ export function MobileControl({ clearCutId, children }: Props) {
 						Détail
 					</Button>
 				)}
-				<CollapsibleTrigger asChild>
+				<SheetTrigger asChild>
 					<IconButton variant="white" icon={<Filter />} position="start">
 						Filtres
 					</IconButton>
-				</CollapsibleTrigger>
+				</SheetTrigger>
 			</div>
 
-			<CollapsibleContent>
-				<AdvancedFilters key={resetVersion} className="mt-6 px-3 bg-background" />
-			</CollapsibleContent>
-		</Collapsible>
+			<SheetContent title="Filtres" className="sm:hidden">
+				<div className="overflow-y-auto">
+					<AdvancedFilters
+						key={resetVersion}
+						className="px-1 bg-background"
+						onClose={() => setOpen(false)}
+					/>
+				</div>
+			</SheetContent>
+		</Sheet>
 	)
 }

--- a/frontend/src/features/clear-cut/store/clear-cuts-slice.ts
+++ b/frontend/src/features/clear-cut/store/clear-cuts-slice.ts
@@ -176,6 +176,12 @@ export const getClearCutsThunk = createAppAsyncThunk<ClearCuts, FiltersRequest>(
 				searchParams.append("swLng", geoBounds.sw.lng.toString())
 				searchParams.append("neLat", geoBounds.ne.lat.toString())
 				searchParams.append("neLng", geoBounds.ne.lng.toString())
+			} else if (
+				(filter === "sortBy" || filter === "sortOrder") &&
+				typeof value === "string"
+			) {
+				// Plain string params must be sent raw (parseParam would JSON-quote them)
+				searchParams.append(filter, value)
 			} else {
 				parseParam(filter, value, searchParams)
 			}
@@ -346,20 +352,23 @@ export const rejectAssignmentThunk = createAppAsyncThunk<void, string>(
 
 export const unassignReportThunk = createAppAsyncThunk<void, string>(
 	"clear-cuts/unassign",
-	async (id, { extra: { api } }) => await api().post(`api/v1/clear-cuts-reports/${id}/unassign`).json()
+	async (id, { extra: { api } }) =>
+		await api().post(`api/v1/clear-cuts-reports/${id}/unassign`).json()
 )
 
-export const updateReportStatusThunk = createAppAsyncThunk<void, { id: string, status: string }>(
-	"clear-cuts/updateStatus",
-	async ({ id, status }, { extra: { api } }) => {
-		await api().put(`api/v1/clear-cuts-reports/${id}`, { json: { status } })
-	}
-)
+export const updateReportStatusThunk = createAppAsyncThunk<
+	void,
+	{ id: string; status: string }
+>("clear-cuts/updateStatus", async ({ id, status }, { extra: { api } }) => {
+	await api().put(`api/v1/clear-cuts-reports/${id}`, { json: { status } })
+})
 
 export const volunteerValidateThunk = createAppAsyncThunk<void, string>(
 	"clear-cuts/volunteerValidate",
 	async (reportId, { extra: { api }, dispatch }) => {
-		await api().post(`api/v1/clear-cuts-reports/${reportId}/volunteer-validate`).json()
+		await api()
+			.post(`api/v1/clear-cuts-reports/${reportId}/volunteer-validate`)
+			.json()
 		dispatch(getClearCutFormThunk({ id: reportId, hasBeenCreated: true }))
 	}
 )
@@ -367,7 +376,9 @@ export const volunteerValidateThunk = createAppAsyncThunk<void, string>(
 export const approveValidationThunk = createAppAsyncThunk<void, string>(
 	"clear-cuts/approveValidation",
 	async (reportId, { extra: { api }, dispatch }) => {
-		await api().post(`api/v1/clear-cuts-reports/${reportId}/approve-validation`).json()
+		await api()
+			.post(`api/v1/clear-cuts-reports/${reportId}/approve-validation`)
+			.json()
 		dispatch(getClearCutFormThunk({ id: reportId }))
 	}
 )
@@ -375,7 +386,9 @@ export const approveValidationThunk = createAppAsyncThunk<void, string>(
 export const rejectValidationThunk = createAppAsyncThunk<void, string>(
 	"clear-cuts/rejectValidation",
 	async (reportId, { extra: { api }, dispatch }) => {
-		await api().post(`api/v1/clear-cuts-reports/${reportId}/reject-validation`).json()
+		await api()
+			.post(`api/v1/clear-cuts-reports/${reportId}/reject-validation`)
+			.json()
 		dispatch(getClearCutFormThunk({ id: reportId }))
 	}
 )

--- a/frontend/src/features/clear-cut/store/filters.slice.ts
+++ b/frontend/src/features/clear-cut/store/filters.slice.ts
@@ -4,7 +4,8 @@ import type { ClearCutStatus } from "@/features/clear-cut/store/clear-cuts"
 import {
 	type FiltersRequest,
 	type FiltersResponse,
-	filtersResponseSchema
+	filtersResponseSchema,
+	type SortableField
 } from "@/features/clear-cut/store/filters"
 import type { Bounds } from "@/features/clear-cut/store/types"
 import { selectFavorites } from "@/features/user/store/me.slice"
@@ -25,7 +26,9 @@ import {
 import { createTypedDraftSafeSelector } from "@/shared/store/selector"
 import type { RootState } from "@/shared/store/store"
 import { createAppAsyncThunk } from "@/shared/store/thunk"
+import type { Sort } from "@/shared/types/list"
 import type { Range } from "@/shared/types/range"
+
 interface PendingFilters {
 	cutYears: SelectableItem<number>[]
 	cutMonths: SelectableItem<number>[]
@@ -51,6 +54,8 @@ export interface FiltersState {
 	ecological_zoning: EventuallyBooleanSelectableItems
 	favorite: EventuallyBooleanSelectableItems
 	with_points?: boolean
+	sortBy: SortableField
+	sortOrder: Sort
 	// pending (UI editing state, not yet applied)
 	isInitialized: boolean
 	resetVersion: number
@@ -77,6 +82,8 @@ export const initialState: FiltersState = {
 	excessive_slope: DEFAULT_EVENTUALLY_BOOLEAN,
 	ecological_zoning: DEFAULT_EVENTUALLY_BOOLEAN,
 	favorite: DEFAULT_EVENTUALLY_BOOLEAN,
+	sortBy: "first_cut_date",
+	sortOrder: "desc",
 	isInitialized: false,
 	resetVersion: 0,
 	pendingFilters: emptyPending
@@ -173,7 +180,10 @@ export const filtersSlice = createSlice({
 			const cleared = {
 				cutYears: state.cutYears.map((y) => ({ ...y, isSelected: false })),
 				cutMonths: state.cutMonths.map((m) => ({ ...m, isSelected: false })),
-				departments: state.departments.map((d) => ({ ...d, isSelected: false })),
+				departments: state.departments.map((d) => ({
+					...d,
+					isSelected: false
+				})),
 				statuses: state.statuses.map((s) => ({ ...s, isSelected: false })),
 				areas: [state.area_range.min, state.area_range.max] as [number, number],
 				excessive_slope: DEFAULT_EVENTUALLY_BOOLEAN.map((x) => ({
@@ -238,6 +248,9 @@ export const filtersSlice = createSlice({
 		},
 		setWithPoints: (state, { payload }: PayloadAction<boolean>) => {
 			state.with_points = payload
+		},
+		toggleSortOrder: (state) => {
+			state.sortOrder = state.sortOrder === "desc" ? "asc" : "desc"
 		}
 	},
 	extraReducers: (builder) => {
@@ -293,6 +306,7 @@ export const {
 		updateCutYear: toggleCutYear,
 		setGeoBounds,
 		setWithPoints,
+		toggleSortOrder,
 		commitFilters,
 		resetFilters
 	}
@@ -312,7 +326,9 @@ export const selectFiltersRequest = createTypedDraftSafeSelector(
 			departments,
 			excessive_slope,
 			favorite,
-			with_points
+			with_points,
+			sortBy,
+			sortOrder
 		},
 		favorites
 	): FiltersRequest | undefined => {
@@ -334,7 +350,9 @@ export const selectFiltersRequest = createTypedDraftSafeSelector(
 			excessiveSlope: excessive_slope.find((item) => item.isSelected)?.item,
 			inReportsIds: selectedFavoriteOption === true ? favorites : undefined,
 			outReportsIds: selectedFavoriteOption === false ? favorites : undefined,
-			withPoints: with_points
+			withPoints: with_points,
+			sortBy,
+			sortOrder
 		}
 	}
 )
@@ -397,4 +415,9 @@ export const selectWithPoints = createTypedDraftSafeSelector(
 export const selectResetVersion = createTypedDraftSafeSelector(
 	selectState,
 	(state) => state.resetVersion
+)
+
+export const selectSortOrder = createTypedDraftSafeSelector(
+	selectState,
+	(state) => state.sortOrder
 )

--- a/frontend/src/features/clear-cut/store/filters.ts
+++ b/frontend/src/features/clear-cut/store/filters.ts
@@ -1,8 +1,13 @@
 import { z } from "zod"
 
 import { clearCutStatusSchema } from "@/features/clear-cut/store/clear-cuts"
+import { sortSchema } from "@/shared/types/list"
 
 import { boundsSchema } from "./types"
+
+export const SORTABLE_FIELDS = ["first_cut_date"] as const
+export const sortableFieldSchema = z.enum(SORTABLE_FIELDS)
+export type SortableField = z.infer<typeof sortableFieldSchema>
 
 const filtersRequestSchema = z.object({
 	cutYears: z.array(z.number()),
@@ -16,7 +21,9 @@ const filtersRequestSchema = z.object({
 	inReportsIds: z.string().array().optional(),
 	outReportsIds: z.string().array().optional(),
 	hasEcologicalZonings: z.boolean().optional(),
-	withPoints: z.boolean().optional()
+	withPoints: z.boolean().optional(),
+	sortBy: sortableFieldSchema.optional(),
+	sortOrder: sortSchema.optional()
 })
 
 export type FiltersRequest = z.infer<typeof filtersRequestSchema>

--- a/frontend/src/features/user/components/LoginForm.tsx
+++ b/frontend/src/features/user/components/LoginForm.tsx
@@ -135,7 +135,7 @@ export function LoginForm() {
 						<Button
 							className="w-full"
 							type="submit"
-							disabled={!form.formState.isValid}
+							disabled={login.status === "loading"}
 						>
 							<LogInIcon />
 							Connexion

--- a/frontend/src/features/user/components/RegisterForm.tsx
+++ b/frontend/src/features/user/components/RegisterForm.tsx
@@ -155,9 +155,7 @@ export function RegisterForm() {
 					<Button
 						className="w-full"
 						type="submit"
-						disabled={
-							!form.formState.isValid || registerState.status === "loading"
-						}
+						disabled={registerState.status === "loading"}
 					>
 						<LogInIcon />
 						S'inscrire

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -104,8 +104,13 @@
 	* {
 		@apply border-border outline-ring/50;
 	}
+	html,
+	body,
+	#root {
+		@apply h-full;
+	}
 	body {
-		@apply bg-background text-foreground;
+		@apply bg-background text-foreground overflow-hidden;
 	}
 }
 

--- a/frontend/src/shared/components/AppLayout.tsx
+++ b/frontend/src/shared/components/AppLayout.tsx
@@ -4,7 +4,7 @@ import { Navbar } from "./Navbar"
 
 export function AppLayout() {
 	return (
-		<div className="sm:flex hidden h-screen ">
+		<div className="sm:flex hidden h-full overflow-hidden">
 			<Navbar />
 			<Outlet />
 		</div>

--- a/frontend/src/shared/components/AppMobileLayout.tsx
+++ b/frontend/src/shared/components/AppMobileLayout.tsx
@@ -5,7 +5,12 @@ import { MobileNavbar } from "@/shared/components/MobileNavbar"
 export function AppMobileLayout() {
 	return (
 		<div className="sm:hidden h-[100dvh] flex flex-col justify-content-between">
-			<div className="flex grow mb-12 overflow-auto">
+			<div
+				className="flex grow overflow-auto"
+				style={{
+					marginBottom: "calc(4rem + env(safe-area-inset-bottom))"
+				}}
+			>
 				<Outlet />
 			</div>
 			<MobileNavbar />

--- a/frontend/src/shared/components/MobileNavbar.tsx
+++ b/frontend/src/shared/components/MobileNavbar.tsx
@@ -1,5 +1,5 @@
 import { useRouterState } from "@tanstack/react-router"
-import { House, ListIcon, LogIn, Settings, User } from "lucide-react"
+import { ListIcon, LogIn, Map as MapIcon, Settings, User } from "lucide-react"
 
 import { useLayout } from "@/features/clear-cut/components/Layout.context"
 import { useConnectedMe } from "@/features/user/store/me.slice"
@@ -17,18 +17,18 @@ export function MobileNavbar() {
 		<nav className="flex sm:hidden items-center shadow justify-around fixed bottom-0 left-0 right-0 bg-white z-[150] border-t h-16 pb-[env(safe-area-inset-bottom)]">
 			<div className="flex items-center justify-around w-full h-full">
 				<MobileNavbarLink
-					to="/"
-					label="Accueil"
-					Icon={House}
-					title="Accueil"
+					to="/clear-cuts"
+					label="Carte"
+					Icon={MapIcon}
+					title="Carte"
 					onClick={() => setLayout("map")}
 					forceActive={isOnClearCutsRoute && layout === "map"}
 				/>
 				<MobileNavbarLink
 					to="/clear-cuts"
-					label="Coupes"
+					label="Liste"
 					Icon={ListIcon}
-					title="Coupes"
+					title="Liste"
 					onClick={() => setLayout("list")}
 					forceActive={isOnClearCutsRoute && layout === "list"}
 				/>

--- a/frontend/src/shared/components/MobileNavbar.tsx
+++ b/frontend/src/shared/components/MobileNavbar.tsx
@@ -1,21 +1,12 @@
 import { useRouterState } from "@tanstack/react-router"
-import {
-	House,
-	ListIcon,
-	LogIn,
-	LogOutIcon,
-	Settings,
-	User
-} from "lucide-react"
+import { House, ListIcon, LogIn, Settings, User } from "lucide-react"
 
 import { useLayout } from "@/features/clear-cut/components/Layout.context"
 import { useConnectedMe } from "@/features/user/store/me.slice"
 import { MobileNavbarLink } from "@/shared/components/MobileNavbarLink"
-import { useLogout } from "@/shared/hooks/auth"
 
 export function MobileNavbar() {
 	const user = useConnectedMe()
-	const handleLogout = useLogout()
 	const { layout, setLayout } = useLayout()
 	const location = useRouterState({ select: (s) => s.location })
 
@@ -23,8 +14,8 @@ export function MobileNavbar() {
 	const isOnClearCutsRoute = location.pathname.startsWith("/clear-cuts")
 
 	return (
-		<nav className="flex sm:hidden py-1 items-center shadow justify-around fixed bottom-0 left-0 right-0 bg-white z-[150] border-t h-12">
-			<div className="flex items-center justify-around w-full">
+		<nav className="flex sm:hidden items-center shadow justify-around fixed bottom-0 left-0 right-0 bg-white z-[150] border-t h-16 pb-[env(safe-area-inset-bottom)]">
+			<div className="flex items-center justify-around w-full h-full">
 				<MobileNavbarLink
 					to="/"
 					label="Accueil"
@@ -63,15 +54,6 @@ export function MobileNavbar() {
 						label="Connexion"
 						Icon={LogIn}
 						title="Connexion"
-					/>
-				)}
-				{user && (
-					<MobileNavbarLink
-						to="/login"
-						label="Déconnexion"
-						Icon={LogOutIcon}
-						onClick={handleLogout}
-						title="Déconnexion"
 					/>
 				)}
 			</div>

--- a/frontend/src/shared/components/MobileNavbarLink.tsx
+++ b/frontend/src/shared/components/MobileNavbarLink.tsx
@@ -35,10 +35,10 @@ export const MobileNavbarLink: React.FC<Props> = ({
 		<Link
 			activeProps={activeProps}
 			inactiveProps={inactiveProps}
-			className="flex flex-col items-center h-full px-1 pt-1 text-xs font-medium "
+			className="flex flex-col items-center justify-center gap-0.5 h-full px-1 text-[11px] font-medium leading-none whitespace-nowrap"
 			{...props}
 		>
-			<Icon className="size-7 " />
+			<Icon className="size-6" />
 			{label}
 		</Link>
 	)

--- a/frontend/src/shared/components/Navbar.tsx
+++ b/frontend/src/shared/components/Navbar.tsx
@@ -19,7 +19,7 @@ export function Navbar({ className }: Props) {
 		<nav
 			className={clsx(
 				className,
-				"hidden sm:flex flex-col items-center bg-primary shadow z-max min-w-20 max-w-20 justify-between py-15"
+				"hidden sm:flex flex-col items-center bg-primary shadow z-max min-w-20 max-w-20 justify-between py-15 overflow-y-auto"
 			)}
 		>
 			<div className="flex flex-col items-center ">

--- a/frontend/src/shared/components/NavbarItem.tsx
+++ b/frontend/src/shared/components/NavbarItem.tsx
@@ -12,11 +12,11 @@ type Props = (ButtonProps | LinkProps) & {
 	Icon: LucideIcon
 }
 const className =
-	"inline-flex items-center border-b-2 h-full px-1 pt-1 text-sm font-medium "
-const inactiveClassName =
-	"border-transparent  text-gray-500 hover:border-gray-300 hover:text-gray-700"
+	"inline-flex items-center justify-center rounded-xl p-2 text-primary-foreground transition-colors"
+const inactiveClassName = "opacity-60 hover:opacity-100 hover:bg-white/10"
+const activeClassName = "opacity-100 bg-white/20"
 export const NavbarItem: React.FC<Props> = ({ Icon, ...props }) => {
-	const StylizedIcon = <Icon className="text-primary-foreground size-11" />
+	const StylizedIcon = <Icon className="size-9" />
 
 	if (props.type === "button") {
 		return (
@@ -32,7 +32,7 @@ export const NavbarItem: React.FC<Props> = ({ Icon, ...props }) => {
 		<Link
 			{...props}
 			activeProps={{
-				className: "border-transparent hover:border-gray-300 text-gray-900"
+				className: activeClassName
 			}}
 			inactiveProps={{
 				className: inactiveClassName

--- a/frontend/src/shared/components/select/Combobox.tsx
+++ b/frontend/src/shared/components/select/Combobox.tsx
@@ -1,7 +1,7 @@
 import { Check } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
 
-import type { ButtonProps } from "@/components/ui/button"
+import { Button, type ButtonProps } from "@/components/ui/button"
 import {
 	Command,
 	CommandEmpty,
@@ -181,8 +181,16 @@ export function Combobox<TItem>({
 						</CommandGroup>
 					</CommandList>
 				</Command>
-				{hasReset && (
-					<ResetButton disabled={selectedItemsCount === 0} onClick={reset} />
+				{(hasReset || changeOnClose) && (
+					<div className="flex justify-end gap-2 pt-2">
+						{hasReset && (
+							<ResetButton
+								disabled={selectedItemsCount === 0}
+								onClick={reset}
+							/>
+						)}
+						{changeOnClose && <Button onClick={close}>Valider</Button>}
+					</div>
 				)}
 			</PopoverContent>
 		</Popover>

--- a/frontend/src/shared/components/select/Combobox.tsx
+++ b/frontend/src/shared/components/select/Combobox.tsx
@@ -143,7 +143,7 @@ export function Combobox<TItem>({
 				</ExpandButton>
 			</PopoverTrigger>
 
-			<PopoverContent>
+			<PopoverContent className="z-[210]">
 				<Command
 					filter={(value, search, keywords) => {
 						const extendValue = normalizeString(

--- a/frontend/src/shared/form/UploadingContext.tsx
+++ b/frontend/src/shared/form/UploadingContext.tsx
@@ -1,0 +1,58 @@
+import {
+	createContext,
+	type ReactNode,
+	useCallback,
+	useContext,
+	useMemo,
+	useRef,
+	useState
+} from "react"
+
+type UploadingContextValue = {
+	/** True while at least one image field is uploading. */
+	isUploading: boolean
+	/** Register/unregister an upload in progress for a given field id. */
+	setFieldUploading: (id: string, uploading: boolean) => void
+}
+
+const UploadingContext = createContext<UploadingContextValue>({
+	isUploading: false,
+	setFieldUploading: () => {}
+})
+
+/**
+ * Tracks how many image fields are currently uploading so that ancestors
+ * (e.g. the "Sauvegarder" button) can react to in-flight uploads and avoid
+ * saving the form with an incomplete set of photos.
+ */
+export function UploadingProvider({ children }: { children: ReactNode }) {
+	const [uploadingCount, setUploadingCount] = useState(0)
+	const idsRef = useRef<Set<string>>(new Set())
+
+	const setFieldUploading = useCallback((id: string, uploading: boolean) => {
+		const ids = idsRef.current
+		const wasUploading = ids.has(id)
+		if (uploading && !wasUploading) {
+			ids.add(id)
+			setUploadingCount(ids.size)
+		} else if (!uploading && wasUploading) {
+			ids.delete(id)
+			setUploadingCount(ids.size)
+		}
+	}, [])
+
+	const value = useMemo(
+		() => ({ isUploading: uploadingCount > 0, setFieldUploading }),
+		[uploadingCount, setFieldUploading]
+	)
+
+	return (
+		<UploadingContext.Provider value={value}>
+			{children}
+		</UploadingContext.Provider>
+	)
+}
+
+export function useUploadingTracker() {
+	return useContext(UploadingContext)
+}

--- a/frontend/src/shared/form/components/FormFieldLayout.tsx
+++ b/frontend/src/shared/form/components/FormFieldLayout.tsx
@@ -55,7 +55,11 @@ export function FormFieldLayout<
 					) : null}
 				</div>
 			)}
-			<div className="flex flex-grow-1 flex-col">
+			<div
+				className={clsx("flex flex-grow-1 flex-col", {
+					"w-full": orientation === "vertical"
+				})}
+			>
 				{withControl ? <FormControl>{children}</FormControl> : children}
 				<FormMessage />
 			</div>

--- a/frontend/src/shared/form/components/FormS3ImageUpload.tsx
+++ b/frontend/src/shared/form/components/FormS3ImageUpload.tsx
@@ -1,9 +1,18 @@
-import { AlertCircle, Camera, ChevronLeft, ChevronRight, ImagePlus, X, ZoomIn } from "lucide-react"
-import { type ChangeEvent, useEffect, useRef, useState } from "react"
+import {
+	AlertCircle,
+	Camera,
+	ChevronLeft,
+	ChevronRight,
+	ImagePlus,
+	X,
+	ZoomIn
+} from "lucide-react"
+import { type ChangeEvent, useEffect, useId, useRef, useState } from "react"
 import type { FieldValues } from "react-hook-form"
 
 import { Button } from "@/components/ui/button"
 import { Progress } from "@/components/ui/progress"
+import { useUploadingTracker } from "@/shared/form/UploadingContext"
 import { useImageUpload } from "@/shared/hooks/useImageUpload"
 import { useImageViewer } from "@/shared/hooks/useImageViewer"
 
@@ -35,31 +44,52 @@ function FormS3ImageField<T extends FieldValues>({
 	onSelectedImageIndexChanged,
 	field
 }: FormS3ImageFieldProps<T>) {
-	const { uploadImages, uploading, error, progress } = useImageUpload()
+	const { uploadImages, uploading, error, progress, current, total } =
+		useImageUpload()
 	const { getViewableUrls, loading: viewerLoading } = useImageViewer()
 	const [uploadedImages, setUploadedImages] = useState<string[]>([])
 
 	const galleryInputRef = useRef<HTMLInputElement>(null)
 	const cameraInputRef = useRef<HTMLInputElement>(null)
 
+	// Let ancestors (e.g. the "Sauvegarder" button) know an upload is running so
+	// the form is not saved with an incomplete set of photos.
+	const fieldId = useId()
+	const { setFieldUploading } = useUploadingTracker()
+	useEffect(() => {
+		setFieldUploading(fieldId, uploading)
+		return () => setFieldUploading(fieldId, false)
+	}, [uploading, fieldId, setFieldUploading])
+
 	const handleFiles = async (files: FileList | null) => {
 		if (!files || files.length === 0) return
-		try {
-			const uploaded = await uploadImages(files, reportId)
+		// `uploadImages` never throws: it returns whatever succeeded plus per-file
+		// errors. We always commit the successful uploads so photos already sent
+		// to S3 are recorded in the form (and persisted to localStorage) even if
+		// some files failed — no more "4 out of 8 photos disappeared".
+		const { uploaded } = await uploadImages(files, reportId)
+		if (uploaded.length > 0) {
 			const s3Keys = uploaded.map((img) => img.key)
 			const newUploadedImages = [...uploadedImages, ...s3Keys]
 			setUploadedImages(newUploadedImages)
 			field.onChange(newUploadedImages)
-		} catch (_e) {}
+		}
 	}
 
-	const handleGalleryChange = (e: ChangeEvent<HTMLInputElement>) =>
+	const handleGalleryChange = (e: ChangeEvent<HTMLInputElement>) => {
 		handleFiles(e.target.files)
-	const handleCameraChange = (e: ChangeEvent<HTMLInputElement>) =>
+		// Reset so re-selecting the same files fires `change` again (e.g. retry).
+		e.target.value = ""
+	}
+	const handleCameraChange = (e: ChangeEvent<HTMLInputElement>) => {
 		handleFiles(e.target.files)
+		e.target.value = ""
+	}
 
 	const removeImageWithField = (indexToRemove: number) => {
-		const newUploadedImages = uploadedImages.filter((_, i) => i !== indexToRemove)
+		const newUploadedImages = uploadedImages.filter(
+			(_, i) => i !== indexToRemove
+		)
 		const newPreviewUrls = previewUrls.filter((_, i) => i !== indexToRemove)
 		setUploadedImages(newUploadedImages)
 		onPreviewUrlsChanged(newPreviewUrls)
@@ -146,14 +176,36 @@ function FormS3ImageField<T extends FieldValues>({
 						fill="none"
 						aria-hidden="true"
 					>
-						<circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-						<path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+						<circle
+							className="opacity-25"
+							cx="12"
+							cy="12"
+							r="10"
+							stroke="currentColor"
+							strokeWidth="4"
+						/>
+						<path
+							className="opacity-75"
+							fill="currentColor"
+							d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+						/>
 					</svg>
-					{uploading ? "Envoi en cours…" : "Chargement des photos…"}
+					{uploading
+						? total > 0
+							? `Envoi de la photo ${current}/${total}…`
+							: "Envoi en cours…"
+						: "Chargement des photos…"}
 				</div>
 			)}
 
-			{uploading && <Progress value={progress} className="w-full" />}
+			{uploading && (
+				<div className="flex items-center gap-2">
+					<Progress value={progress} className="w-full" />
+					<span className="text-xs text-gray-500 shrink-0 tabular-nums">
+						{Math.round(progress)}%
+					</span>
+				</div>
+			)}
 
 			{error && (
 				<div className="flex items-start gap-2 text-sm text-red-600 mt-1">
@@ -221,7 +273,9 @@ export function FormS3ImageUpload<T extends FieldValues = FieldValues>({
 	...props
 }: Forms3ImageUploadProps<T>) {
 	const [previewUrls, setPreviewUrls] = useState<string[]>([])
-	const [selectedImageIndex, setSelectedImageIndex] = useState<number | undefined>()
+	const [selectedImageIndex, setSelectedImageIndex] = useState<
+		number | undefined
+	>()
 
 	useEffect(() => {
 		const handleKeyDown = (event: KeyboardEvent) => {
@@ -230,13 +284,17 @@ export function FormS3ImageUpload<T extends FieldValues = FieldValues>({
 				case "ArrowLeft":
 					event.preventDefault()
 					setSelectedImageIndex(
-						selectedImageIndex > 0 ? selectedImageIndex - 1 : previewUrls.length - 1
+						selectedImageIndex > 0
+							? selectedImageIndex - 1
+							: previewUrls.length - 1
 					)
 					break
 				case "ArrowRight":
 					event.preventDefault()
 					setSelectedImageIndex(
-						selectedImageIndex < previewUrls.length - 1 ? selectedImageIndex + 1 : 0
+						selectedImageIndex < previewUrls.length - 1
+							? selectedImageIndex + 1
+							: 0
 					)
 					break
 				case "Escape":
@@ -290,7 +348,9 @@ export function FormS3ImageUpload<T extends FieldValues = FieldValues>({
 									onClick={(e) => {
 										e.stopPropagation()
 										setSelectedImageIndex(
-											selectedImageIndex > 0 ? selectedImageIndex - 1 : previewUrls.length - 1
+											selectedImageIndex > 0
+												? selectedImageIndex - 1
+												: previewUrls.length - 1
 										)
 									}}
 								>
@@ -304,7 +364,9 @@ export function FormS3ImageUpload<T extends FieldValues = FieldValues>({
 									onClick={(e) => {
 										e.stopPropagation()
 										setSelectedImageIndex(
-											selectedImageIndex < previewUrls.length - 1 ? selectedImageIndex + 1 : 0
+											selectedImageIndex < previewUrls.length - 1
+												? selectedImageIndex + 1
+												: 0
 										)
 									}}
 								>

--- a/frontend/src/shared/hooks/useImageUpload.ts
+++ b/frontend/src/shared/hooks/useImageUpload.ts
@@ -47,6 +47,10 @@ function inferMimeType(file: File): string {
 	return EXTENSION_TO_MIME[ext] ?? "image/jpeg"
 }
 
+// Doit rester aligné avec MAX_UPLOAD_SIZE_BYTES côté backend (app/config.py).
+const MAX_FILE_SIZE = 25 * 1024 * 1024
+const MAX_FILE_SIZE_LABEL = "25 Mo"
+
 export function useImageUpload(): UseImageUploadResult {
 	const [uploading, setUploading] = useState(false)
 	const [error, setError] = useState<string | null>(null)
@@ -61,76 +65,87 @@ export function useImageUpload(): UseImageUploadResult {
 		setProgress(0)
 
 		try {
+			const token = getStoredToken()
+			if (!token) {
+				const message = "Vous devez être connecté pour envoyer des photos."
+				setError(message)
+				throw new Error(message)
+			}
+
+			const authenticatedApi = api.extend({
+				headers: { Authorization: `Bearer ${token.accessToken}` }
+			})
+
 			const uploadedImages: UploadedImage[] = []
+			const failures: string[] = []
 			const totalFiles = files.length
 
 			for (let i = 0; i < totalFiles; i++) {
 				const file = files[i]
-				const contentType = inferMimeType(file)
+				try {
+					const contentType = inferMimeType(file)
 
-				if (!contentType.startsWith("image/")) {
-					throw new Error(`Le fichier "${file.name}" n'est pas une image.`)
-				}
+					if (!contentType.startsWith("image/")) {
+						throw new Error(`"${file.name}" n'est pas une image`)
+					}
 
-				const maxSize = 10 * 1024 * 1024
-				if (file.size > maxSize) {
-					throw new Error(
-						`Le fichier "${file.name}" est trop volumineux (${(file.size / 1024 / 1024).toFixed(1)} Mo). Taille maximale : 10 Mo.`
+					if (file.size > MAX_FILE_SIZE) {
+						throw new Error(
+							`"${file.name}" est trop volumineux (${(file.size / 1024 / 1024).toFixed(1)} Mo, max ${MAX_FILE_SIZE_LABEL})`
+						)
+					}
+
+					const uploadRequest: ImageUploadRequest = {
+						filename: file.name,
+						content_type: contentType,
+						file_size: file.size,
+						report_id: reportId
+					}
+
+					const response = await authenticatedApi
+						.post("api/v1/images/upload-url", { json: uploadRequest })
+						.json<ImageUploadResponse>()
+
+					const formData = new FormData()
+					for (const [key, value] of Object.entries(response.fields)) {
+						formData.append(key, value)
+					}
+					formData.append("file", file)
+
+					const uploadResponse = await fetch(response.uploadUrl, {
+						method: "POST",
+						body: formData
+					})
+
+					if (!uploadResponse.ok) {
+						throw new Error(
+							`échec de l'envoi de "${file.name}" (${uploadResponse.status})`
+						)
+					}
+
+					uploadedImages.push({
+						fileUrl: response.fileUrl,
+						key: response.key,
+						filename: file.name
+					})
+				} catch (fileErr) {
+					// On n'interrompt pas le lot : les autres photos valides doivent
+					// quand même être envoyées. On collecte les fichiers en échec.
+					failures.push(
+						fileErr instanceof Error ? fileErr.message : `"${file.name}"`
 					)
+				} finally {
+					setProgress(((i + 1) / totalFiles) * 100)
 				}
+			}
 
-				const token = getStoredToken()
-				if (!token) {
-					throw new Error("Vous devez être connecté pour envoyer des photos.")
-				}
-
-				const authenticatedApi = api.extend({
-					headers: { Authorization: `Bearer ${token.accessToken}` }
-				})
-
-				const uploadRequest: ImageUploadRequest = {
-					filename: file.name,
-					content_type: contentType,
-					file_size: file.size,
-					report_id: reportId
-				}
-
-				const response = await authenticatedApi
-					.post("api/v1/images/upload-url", { json: uploadRequest })
-					.json<ImageUploadResponse>()
-
-				const formData = new FormData()
-				for (const [key, value] of Object.entries(response.fields)) {
-					formData.append(key, value)
-				}
-				formData.append("file", file)
-
-				const uploadResponse = await fetch(response.uploadUrl, {
-					method: "POST",
-					body: formData
-				})
-
-				if (!uploadResponse.ok) {
-					throw new Error(
-						`Échec de l'envoi de "${file.name}" (${uploadResponse.status} ${uploadResponse.statusText}).`
-					)
-				}
-
-				uploadedImages.push({
-					fileUrl: response.fileUrl,
-					key: response.key,
-					filename: file.name
-				})
-
-				setProgress(((i + 1) / totalFiles) * 100)
+			if (failures.length > 0) {
+				setError(
+					`Certaines photos n'ont pas été ajoutées : ${failures.join(" ; ")}.`
+				)
 			}
 
 			return uploadedImages
-		} catch (err) {
-			const errorMessage =
-				err instanceof Error ? err.message : "Erreur lors de l'envoi de la photo."
-			setError(errorMessage)
-			throw err
 		} finally {
 			setUploading(false)
 		}

--- a/frontend/src/shared/hooks/useImageUpload.ts
+++ b/frontend/src/shared/hooks/useImageUpload.ts
@@ -24,11 +24,26 @@ export interface UploadedImage {
 	filename: string
 }
 
+export interface UploadError {
+	filename: string
+	message: string
+}
+
+export interface UploadResult {
+	uploaded: UploadedImage[]
+	errors: UploadError[]
+}
+
 export interface UseImageUploadResult {
-	uploadImages: (files: FileList, reportId?: string) => Promise<UploadedImage[]>
+	uploadImages: (files: FileList, reportId?: string) => Promise<UploadResult>
 	uploading: boolean
 	error: string | null
+	/** Overall progress of the current batch, 0-100. */
 	progress: number
+	/** Number of the photo currently being sent (1-based) in the current batch. */
+	current: number
+	/** Total number of photos in the current batch. */
+	total: number
 }
 
 const EXTENSION_TO_MIME: Record<string, string> = {
@@ -41,115 +56,171 @@ const EXTENSION_TO_MIME: Record<string, string> = {
 	heif: "image/jpeg"
 }
 
+const MAX_FILE_SIZE = 10 * 1024 * 1024
+/** Per-file upload attempts (1 initial + retries) to survive flaky networks. */
+const MAX_ATTEMPTS = 3
+/** Abort a single attempt after this delay to avoid hanging on dead networks. */
+const ATTEMPT_TIMEOUT_MS = 30_000
+
 function inferMimeType(file: File): string {
 	if (file.type && file.type.startsWith("image/")) return file.type
 	const ext = file.name.split(".").pop()?.toLowerCase() ?? ""
 	return EXTENSION_TO_MIME[ext] ?? "image/jpeg"
 }
 
-// Doit rester aligné avec MAX_UPLOAD_SIZE_BYTES côté backend (app/config.py).
-const MAX_FILE_SIZE = 25 * 1024 * 1024
-const MAX_FILE_SIZE_LABEL = "25 Mo"
+const delay = (ms: number) =>
+	new Promise((resolve) => {
+		setTimeout(resolve, ms)
+	})
+
+/**
+ * Uploads a single file with retries + a per-attempt timeout. Throws only when
+ * every attempt has failed, so the caller can record a per-file error without
+ * losing the photos that did succeed.
+ */
+async function uploadSingleFile(
+	file: File,
+	contentType: string,
+	reportId: string | undefined,
+	accessToken: string
+): Promise<UploadedImage> {
+	// Keep `api`'s default retry config so a 401 still triggers ky's token
+	// refresh (long form sessions can outlive the access token). Our own loop
+	// below adds retries for the raw S3 `fetch`, which ky does not manage.
+	const authenticatedApi = api.extend({
+		headers: { Authorization: `Bearer ${accessToken}` },
+		timeout: ATTEMPT_TIMEOUT_MS
+	})
+
+	const uploadRequest: ImageUploadRequest = {
+		filename: file.name,
+		content_type: contentType,
+		file_size: file.size,
+		report_id: reportId
+	}
+
+	let lastError: unknown
+	for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+		try {
+			const response = await authenticatedApi
+				.post("api/v1/images/upload-url", { json: uploadRequest })
+				.json<ImageUploadResponse>()
+
+			const formData = new FormData()
+			for (const [key, value] of Object.entries(response.fields)) {
+				formData.append(key, value)
+			}
+			formData.append("file", file)
+
+			const controller = new AbortController()
+			const timer = setTimeout(() => controller.abort(), ATTEMPT_TIMEOUT_MS)
+			try {
+				const uploadResponse = await fetch(response.uploadUrl, {
+					method: "POST",
+					body: formData,
+					signal: controller.signal
+				})
+				if (!uploadResponse.ok) {
+					throw new Error(
+						`Échec de l'envoi (${uploadResponse.status} ${uploadResponse.statusText}).`
+					)
+				}
+			} finally {
+				clearTimeout(timer)
+			}
+
+			return {
+				fileUrl: response.fileUrl,
+				key: response.key,
+				filename: file.name
+			}
+		} catch (err) {
+			lastError = err
+			if (attempt < MAX_ATTEMPTS) {
+				await delay(1000 * attempt)
+			}
+		}
+	}
+	throw lastError instanceof Error
+		? lastError
+		: new Error("Échec de l'envoi de la photo.")
+}
 
 export function useImageUpload(): UseImageUploadResult {
 	const [uploading, setUploading] = useState(false)
 	const [error, setError] = useState<string | null>(null)
 	const [progress, setProgress] = useState(0)
+	const [current, setCurrent] = useState(0)
+	const [total, setTotal] = useState(0)
 
 	const uploadImages = async (
 		files: FileList,
 		reportId?: string
-	): Promise<UploadedImage[]> => {
+	): Promise<UploadResult> => {
 		setUploading(true)
 		setError(null)
 		setProgress(0)
+		setCurrent(0)
+		setTotal(files.length)
+
+		const uploaded: UploadedImage[] = []
+		const errors: UploadError[] = []
 
 		try {
 			const token = getStoredToken()
-			if (!token) {
-				const message = "Vous devez être connecté pour envoyer des photos."
-				setError(message)
-				throw new Error(message)
-			}
-
-			const authenticatedApi = api.extend({
-				headers: { Authorization: `Bearer ${token.accessToken}` }
-			})
-
-			const uploadedImages: UploadedImage[] = []
-			const failures: string[] = []
 			const totalFiles = files.length
 
 			for (let i = 0; i < totalFiles; i++) {
 				const file = files[i]
-				try {
-					const contentType = inferMimeType(file)
+				setCurrent(i + 1)
 
-					if (!contentType.startsWith("image/")) {
-						throw new Error(`"${file.name}" n'est pas une image`)
+				try {
+					if (!token) {
+						throw new Error("Vous devez être connecté pour envoyer des photos.")
 					}
 
+					const contentType = inferMimeType(file)
+					if (!contentType.startsWith("image/")) {
+						throw new Error("Ce fichier n'est pas une image.")
+					}
 					if (file.size > MAX_FILE_SIZE) {
 						throw new Error(
-							`"${file.name}" est trop volumineux (${(file.size / 1024 / 1024).toFixed(1)} Mo, max ${MAX_FILE_SIZE_LABEL})`
+							`Photo trop volumineuse (${(file.size / 1024 / 1024).toFixed(1)} Mo, max 10 Mo).`
 						)
 					}
 
-					const uploadRequest: ImageUploadRequest = {
-						filename: file.name,
-						content_type: contentType,
-						file_size: file.size,
-						report_id: reportId
-					}
-
-					const response = await authenticatedApi
-						.post("api/v1/images/upload-url", { json: uploadRequest })
-						.json<ImageUploadResponse>()
-
-					const formData = new FormData()
-					for (const [key, value] of Object.entries(response.fields)) {
-						formData.append(key, value)
-					}
-					formData.append("file", file)
-
-					const uploadResponse = await fetch(response.uploadUrl, {
-						method: "POST",
-						body: formData
-					})
-
-					if (!uploadResponse.ok) {
-						throw new Error(
-							`échec de l'envoi de "${file.name}" (${uploadResponse.status})`
-						)
-					}
-
-					uploadedImages.push({
-						fileUrl: response.fileUrl,
-						key: response.key,
-						filename: file.name
-					})
-				} catch (fileErr) {
-					// On n'interrompt pas le lot : les autres photos valides doivent
-					// quand même être envoyées. On collecte les fichiers en échec.
-					failures.push(
-						fileErr instanceof Error ? fileErr.message : `"${file.name}"`
+					const image = await uploadSingleFile(
+						file,
+						contentType,
+						reportId,
+						token.accessToken
 					)
+					uploaded.push(image)
+				} catch (err) {
+					errors.push({
+						filename: file.name,
+						message:
+							err instanceof Error
+								? err.message
+								: "Erreur lors de l'envoi de la photo."
+					})
 				} finally {
 					setProgress(((i + 1) / totalFiles) * 100)
 				}
 			}
 
-			if (failures.length > 0) {
+			if (errors.length > 0) {
+				const plural = errors.length > 1 ? "s" : ""
 				setError(
-					`Certaines photos n'ont pas été ajoutées : ${failures.join(" ; ")}.`
+					`${errors.length} photo${plural} n'${errors.length > 1 ? "ont" : "a"} pas pu être envoyée${plural}. Réessayez de les ajouter.`
 				)
 			}
 
-			return uploadedImages
+			return { uploaded, errors }
 		} finally {
 			setUploading(false)
 		}
 	}
 
-	return { uploadImages, uploading, error, progress }
+	return { uploadImages, uploading, error, progress, current, total }
 }

--- a/frontend/src/shared/hooks/useOnlineStatus.ts
+++ b/frontend/src/shared/hooks/useOnlineStatus.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react"
+
+/**
+ * Reactive wrapper around `navigator.onLine`.
+ *
+ * Returns `true` when the browser reports an active network connection and
+ * updates whenever the connection is lost or restored. Used to give the user
+ * explicit feedback when they are offline (clear cuts are often surveyed in
+ * areas with poor coverage).
+ */
+export function useOnlineStatus(): boolean {
+	const [online, setOnline] = useState(() =>
+		typeof navigator === "undefined" ? true : navigator.onLine
+	)
+
+	useEffect(() => {
+		const handleOnline = () => setOnline(true)
+		const handleOffline = () => setOnline(false)
+		window.addEventListener("online", handleOnline)
+		window.addEventListener("offline", handleOffline)
+		return () => {
+			window.removeEventListener("online", handleOnline)
+			window.removeEventListener("offline", handleOffline)
+		}
+	}, [])
+
+	return online
+}

--- a/frontend/src/styles/leaflet.css
+++ b/frontend/src/styles/leaflet.css
@@ -23,3 +23,27 @@
 .leaflet-interactive.clear-cutting-area:hover {
 	fill-opacity: 0.95;
 }
+
+/* "i" badge centered on a clear-cut zone, hinting that a click opens its details. */
+.clear-cut-info-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 22px;
+	height: 22px;
+	border-radius: 9999px;
+	background: #ffffff;
+	color: #1f2937;
+	border: 1px solid rgba(0, 0, 0, 0.15);
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+	font-family: Georgia, "Times New Roman", serif;
+	font-style: italic;
+	font-weight: 700;
+	font-size: 14px;
+	line-height: 1;
+	cursor: pointer;
+}
+
+.clear-cut-info-icon:hover {
+	background: #f3f4f6;
+}

--- a/frontend/src/test/page-object/advanced-filters.ts
+++ b/frontend/src/test/page-object/advanced-filters.ts
@@ -6,7 +6,9 @@ type SwitchLabel = "Favoris" | "Zone protégée" | "Pente excessive"
 export function advancedFilters({ user }: Options) {
 	return {
 		open: async () => {
-			await user.click(await screen.findByText("Filtres"))
+			// The label text is hidden on narrow viewports; target the button by its
+			// accessible name (from the title attribute) so it works at any width.
+			await user.click(await screen.findByRole("button", { name: "Filtres" }))
 		},
 		favorite: toggleInput({ user, label: "Favoris" }),
 		excessive_slop: toggleInput({ user, label: "Pente excessive" }),
@@ -19,9 +21,13 @@ function toggleInput({ user, label }: SwitchOptions) {
 	return {
 		toggle: async (value: boolean | undefined) => {
 			const labelElement = await screen.findByText(label)
-			const button = await within(
-				labelElement.nextElementSibling as HTMLElement
-			).findByText(value === true ? "Oui" : value === false ? "Non" : "Tout")
+			// The label and its toggle group share a parent wrapper; scope the
+			// option lookup there (robust whether filters render inline or in a sheet).
+			const group = (labelElement.parentElement ??
+				labelElement.nextElementSibling) as HTMLElement
+			const button = await within(group).findByText(
+				value === true ? "Oui" : value === false ? "Non" : "Tout"
+			)
 			await user.click(button)
 		}
 	}

--- a/frontend/src/test/page-object/clear-cuts.ts
+++ b/frontend/src/test/page-object/clear-cuts.ts
@@ -6,9 +6,18 @@ import { clearCutItem } from "@/test/page-object/clear-cuts-item"
 type Options = { user: UserEvent } & waitForOptions
 export function clearCuts({ user, ...options }: Options) {
 	const findTitle = () => screen.findByText("COUPES RASES", undefined, options)
-	const findContainer = async () =>
-		(await findTitle()).parentElement?.parentElement?.nextElementSibling
-			?.firstChild as HTMLElement
+	// Wait for the list header, then grab the list itself by role. This is robust
+	// to header layout changes (inline collapsible vs. portal sheet for filters).
+	// `hidden: true` is needed because an open filter sheet marks the rest of the
+	// page as aria-hidden for focus trapping.
+	const findContainer = async () => {
+		await findTitle()
+		return screen.findByRole(
+			"list",
+			{ name: "Liste des coupes rases", hidden: true },
+			options
+		)
+	}
 	return {
 		filters: {},
 		list: {

--- a/start_docker.sh
+++ b/start_docker.sh
@@ -5,16 +5,16 @@ set -e
 
 echo "Démarrage automatique de Docker..."
 open -a Docker
-echo "Attente de Docker (10s)..."
-sleep 10
+echo "Attente du démon Docker..."
+until docker info >/dev/null 2>&1; do sleep 1; done
 
 echo "1. Construction des images et démarrage de la base de données..."
 docker compose build
-docker compose up -d db pgadmin
+# --wait bloque jusqu'à ce que le healthcheck Postgres soit OK (plus de sleep en dur)
+docker compose up -d --wait db
+docker compose up -d pgadmin
 
 echo "2. Initialisation de la base de données (Migrations et seeding)..."
-echo "Attente que Postgres soit prêt..."
-sleep 15
 docker compose run --rm backend poetry run alembic upgrade head
 docker compose run --rm backend poetry run python -m seed_dev
 

--- a/start_local.sh
+++ b/start_local.sh
@@ -3,11 +3,16 @@
 
 echo "Démarrage automatique de Docker..."
 open -a Docker
-echo "Attente de Docker (10s)..."
-sleep 10
+echo "Attente du démon Docker..."
+until docker info >/dev/null 2>&1; do sleep 1; done
 
-echo "1. Démarrage de la base de données..."
-docker compose up -d db pgadmin
+echo "1. Démarrage de la base de données (attente du healthcheck)..."
+docker compose up -d --wait db
+docker compose up -d pgadmin
+
+echo "1b. Migrations + seed des données de dev (via le conteneur backend)..."
+docker compose run --rm backend poetry run alembic upgrade head
+docker compose run --rm backend poetry run python -m seed_dev
 
 echo "2. Démarrage de l'API (Backend)..."
 osascript -e 'tell app "Terminal" to do script "cd \"'$PWD'/backend\" && source .venv/bin/activate && python3 -m poetry run python -m app.main --host=0.0.0.0 --port=8080 --reload --proxy-headers --forwarded-allow-ips=*"'


### PR DESCRIPTION
## Contexte

Regroupe les corrections et améliorations de la branche `fix-retour`, indépendantes de la fonctionnalité d'édition des infos/périmètre (qui fait l'objet d'une PR séparée, empilée sur celle-ci).

## Contenu

- **Formulaire** : élargissement des zones de saisie, correction de l'incohérence d'affichage du bénévole en charge, correction des pertes de données à l'envoi des photos.
- **Auth** : correction du bouton de connexion grisé au retour après expiration de session.
- **Carte** : ergonomie de la saisie et du popup (#243).
- **Filtres** : bouton de validation et tri par date de coupe.
- **Upload** : taille max configurable et corrections d'affichage.
- **Seed de dev** : jeu de données réaliste (départements forestiers, communes, zones Natura 2000, utilisateurs, reports couvrant tous les statuts/cas limites), correction du bug location/boundary, démarrage Docker/local robuste (healthchecks), documentation README.

## Note

Cette PR est la base de la PR #247 (édition des infos initiales et du périmètre, issue #240).